### PR TITLE
fix(styles): align section title accent with primary palette

### DIFF
--- a/app/assets/styles/_variables.scss
+++ b/app/assets/styles/_variables.scss
@@ -1,9 +1,8 @@
 // Colors
 $primary-color: #f97316; // orange-500
+$primary-color-strong: #9a3412; // orange-800
+$primary-color-strong-hover: #7c2d12; // orange-900
 $bg-dark: #111827; // gray-900
-$section-title-surface: #1f2937; // gray-800
-$section-title-surface-hover: $bg-dark;
-$section-title-border: #374151; // gray-700
 $bg-card: rgba(31, 41, 55, 0.5); // gray-800/50
 $border-color: rgba(55, 65, 81, 0.5); // gray-700/50
 $text-primary: #ffffff;

--- a/app/assets/styles/_variables.scss
+++ b/app/assets/styles/_variables.scss
@@ -1,8 +1,9 @@
 // Colors
 $primary-color: #f97316; // orange-500
-$primary-color-strong: #9a3412; // orange-800
-$primary-color-strong-hover: #7c2d12; // orange-900
 $bg-dark: #111827; // gray-900
+$section-title-surface: #1f2937; // gray-800
+$section-title-surface-hover: $bg-dark;
+$section-title-border: #374151; // gray-700
 $bg-card: rgba(31, 41, 55, 0.5); // gray-800/50
 $border-color: rgba(55, 65, 81, 0.5); // gray-700/50
 $text-primary: #ffffff;

--- a/app/assets/styles/_variables.scss
+++ b/app/assets/styles/_variables.scss
@@ -1,7 +1,7 @@
 // Colors
 $primary-color: #f97316; // orange-500
-$primary-color-strong: #9a3412; // orange-800
-$primary-color-strong-hover: #7c2d12; // orange-900
+$primary-color-strong: #c2410c; // orange-700
+$primary-color-strong-hover: #9a3412; // orange-800
 $bg-dark: #111827; // gray-900
 $bg-card: rgba(31, 41, 55, 0.5); // gray-800/50
 $border-color: rgba(55, 65, 81, 0.5); // gray-700/50

--- a/app/components/Education/Education.vue
+++ b/app/components/Education/Education.vue
@@ -6,7 +6,6 @@
     <SectionTitle
       id="education"
       accent
-      contrast-context="dark"
       :label="t('cv.education')"
     />
     <div class="space-y-6" role="list" data-testid="education-list">

--- a/app/components/Education/Education.vue
+++ b/app/components/Education/Education.vue
@@ -3,7 +3,12 @@
     class="text-center py-10 bg-gray-700"
     data-testid="education-section"
   >
-    <SectionTitle id="education" accent :label="t('cv.education')" />
+    <SectionTitle
+      id="education"
+      accent
+      contrast-context="dark"
+      :label="t('cv.education')"
+    />
     <div class="space-y-6" role="list" data-testid="education-list">
       <article
         v-for="(edu, idx) in educations"

--- a/app/components/Hobbies/Hobbies.vue
+++ b/app/components/Hobbies/Hobbies.vue
@@ -1,6 +1,11 @@
 <template>
   <section class="text-center py-10 bg-gray-700" data-testid="hobbies-section">
-    <SectionTitle id="hobbies" accent :label="t('cv.hobbies')" />
+    <SectionTitle
+      id="hobbies"
+      accent
+      contrast-context="dark"
+      :label="t('cv.hobbies')"
+    />
     <ul
       class="hobby-list"
       role="list"

--- a/app/components/Hobbies/Hobbies.vue
+++ b/app/components/Hobbies/Hobbies.vue
@@ -3,7 +3,6 @@
     <SectionTitle
       id="hobbies"
       accent
-      contrast-context="dark"
       :label="t('cv.hobbies')"
     />
     <ul

--- a/app/components/ui/SectionTitle.scss
+++ b/app/components/ui/SectionTitle.scss
@@ -14,37 +14,43 @@
 }
 
 .section-title--accent {
+  // Darker accent for light surfaces to satisfy contrast.
+  color: $primary-color-strong;
+}
+
+.section-title--on-dark.section-title--accent {
+  // Use brand accent on dark surfaces where contrast is sufficient.
   color: $primary-color;
 }
 
 .section-title a {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.25rem 0.75rem;
-  border: 1px solid $section-title-border;
-  border-radius: 9999px;
-  background-color: $section-title-surface;
   color: inherit;
   text-decoration: none;
-  transition:
-    color 0.2s,
-    border-color 0.2s,
-    background-color 0.2s;
+  transition: color 0.2s;
 }
 
 .section-title a:hover {
-  color: $primary-color;
-  border-color: $primary-color;
-  background-color: $section-title-surface-hover;
-  text-decoration: underline;
+  color: $primary-color-strong-hover;
 }
 
-.section-title a:focus-visible {
+.section-title--on-dark a:hover {
+  color: $primary-color;
+  filter: brightness(1.08);
+}
+
+.section-title--on-dark a:focus-visible {
   outline: 2px solid $primary-color;
+}
+
+.section-title:not(.section-title--on-dark) a:focus-visible {
+  outline: 2px solid $primary-color-strong-hover;
   outline-offset: 4px;
-  border-color: $primary-color;
-  background-color: $section-title-surface-hover;
+}
+
+.section-title--on-dark a:focus-visible,
+.section-title:not(.section-title--on-dark) a:focus-visible {
+  text-decoration: underline;
+  outline-offset: 4px;
 }
 
 @media print {
@@ -55,7 +61,5 @@
   .section-title a:visited,
   .section-title a:hover {
     color: $text-print;
-    border-color: transparent;
-    background-color: transparent;
   }
 }

--- a/app/components/ui/SectionTitle.scss
+++ b/app/components/ui/SectionTitle.scss
@@ -14,24 +14,37 @@
 }
 
 .section-title--accent {
-  // Darker accent keeps contrast above WCAG AA on light sections.
-  color: $primary-color-strong;
+  color: $primary-color;
 }
 
 .section-title a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid $section-title-border;
+  border-radius: 9999px;
+  background-color: $section-title-surface;
   color: inherit;
   text-decoration: none;
-  transition: color 0.2s;
+  transition:
+    color 0.2s,
+    border-color 0.2s,
+    background-color 0.2s;
 }
 
 .section-title a:hover {
-  color: $primary-color-strong-hover;
+  color: $primary-color;
+  border-color: $primary-color;
+  background-color: $section-title-surface-hover;
   text-decoration: underline;
 }
 
 .section-title a:focus-visible {
-  outline: 2px solid $primary-color-strong-hover;
+  outline: 2px solid $primary-color;
   outline-offset: 4px;
+  border-color: $primary-color;
+  background-color: $section-title-surface-hover;
 }
 
 @media print {
@@ -42,5 +55,7 @@
   .section-title a:visited,
   .section-title a:hover {
     color: $text-print;
+    border-color: transparent;
+    background-color: transparent;
   }
 }

--- a/app/components/ui/SectionTitle.scss
+++ b/app/components/ui/SectionTitle.scss
@@ -18,11 +18,6 @@
   color: $primary-color-strong;
 }
 
-.section-title--on-dark.section-title--accent {
-  // Use brand accent on dark surfaces where contrast is sufficient.
-  color: $primary-color;
-}
-
 .section-title a {
   color: inherit;
   text-decoration: none;
@@ -32,25 +27,10 @@
 .section-title a:hover {
   color: $primary-color-strong-hover;
 }
-
-.section-title--on-dark a:hover {
-  color: $primary-color;
-  filter: brightness(1.08);
-}
-
-.section-title--on-dark a:focus-visible {
-  outline: 2px solid $primary-color;
-}
-
-.section-title:not(.section-title--on-dark) a:focus-visible {
+.section-title a:focus-visible {
   outline: 2px solid $primary-color-strong-hover;
   outline-offset: 4px;
-}
-
-.section-title--on-dark a:focus-visible,
-.section-title:not(.section-title--on-dark) a:focus-visible {
   text-decoration: underline;
-  outline-offset: 4px;
 }
 
 @media print {

--- a/app/components/ui/SectionTitle.vue
+++ b/app/components/ui/SectionTitle.vue
@@ -8,13 +8,11 @@ withDefaults(
     href?: string;
     prefix?: string;
     accent?: boolean;
-    contrastContext?: 'light' | 'dark';
   }>(),
   {
     href: undefined,
     prefix: '# ',
     accent: false,
-    contrastContext: 'light',
   },
 );
 </script>
@@ -22,13 +20,7 @@ withDefaults(
 <template>
   <h2
     :id="id"
-    :class="[
-      'section-title',
-      {
-        'section-title--accent': accent,
-        'section-title--on-dark': contrastContext === 'dark',
-      },
-    ]"
+    :class="['section-title', { 'section-title--accent': accent }]"
   >
     <a :href="href || `#${id}`">{{ prefix }}{{ label }}</a>
   </h2>

--- a/app/components/ui/SectionTitle.vue
+++ b/app/components/ui/SectionTitle.vue
@@ -8,11 +8,13 @@ withDefaults(
     href?: string;
     prefix?: string;
     accent?: boolean;
+    contrastContext?: 'light' | 'dark';
   }>(),
   {
     href: undefined,
     prefix: '# ',
     accent: false,
+    contrastContext: 'light',
   },
 );
 </script>
@@ -20,7 +22,13 @@ withDefaults(
 <template>
   <h2
     :id="id"
-    :class="['section-title', { 'section-title--accent': accent }]"
+    :class="[
+      'section-title',
+      {
+        'section-title--accent': accent,
+        'section-title--on-dark': contrastContext === 'dark',
+      },
+    ]"
   >
     <a :href="href || `#${id}`">{{ prefix }}{{ label }}</a>
   </h2>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep section titles in a clean text-only style (no background treatment)
- resolve CI Lighthouse `color-contrast` failure by tuning section title accent tokens to a contrast-safe orange pair on the actual light content surface
- simplify `SectionTitle` back to a single accent mode (remove dark-context prop/class path)
- keep hover/focus styles accessible while preserving the orange design language

## Files changed
- `app/assets/styles/_variables.scss`
- `app/components/ui/SectionTitle.scss`
- `app/components/ui/SectionTitle.vue`
- `app/components/Education/Education.vue`
- `app/components/Hobbies/Hobbies.vue`

## Validation
- `npm run lint`
- `npm run generate`
- `npx --yes @lhci/cli autorun --config=.lighthouserc.json`
- CI run `25970175778` passed (including Lighthouse job)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa6ca1db-38fa-444f-bfb7-f316ffd2afa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa6ca1db-38fa-444f-bfb7-f316ffd2afa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved section title accent color contrast handling for dark and light backgrounds.
  * Enhanced link hover and focus-visible states with refined color and outline styling.
  * Ensured print-friendly color overrides for section title links and their interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/95gabor/cv/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->