### PR TITLE
feat(cv): add month-aware period dates for experience entries

### DIFF
--- a/app/components/Education/Education.vue
+++ b/app/components/Education/Education.vue
@@ -23,7 +23,7 @@
         </h3>
         <div class="education-details">
           <span class="meta-text">
-            <time :datetime="edu.from" itemprop="dateCreated">{{
+            <time :datetime="toDateTime(edu.from)" itemprop="dateCreated">{{
               formatPeriod(edu.from, edu.end)
             }}</time>
             <span class="meta-separator">|</span>
@@ -43,8 +43,8 @@
           </span>
         </div>
         <p v-if="edu.note" itemprop="description">{{ edu.note[lang] }}</p>
-        <meta itemprop="dateCreated" :content="edu.from" >
-        <meta v-if="edu.end" itemprop="dateModified" :content="edu.end" >
+        <meta itemprop="dateCreated" :content="toDateTime(edu.from)" >
+        <meta v-if="edu.end" itemprop="dateModified" :content="toDateTime(edu.end)" >
       </article>
     </div>
   </section>
@@ -55,6 +55,7 @@ import './Education.scss';
 import type { CVSupportedLangs, Education as EducationType } from '~/types/cv';
 import InlineLink from '../ui/InlineLink.vue';
 import SectionTitle from '../ui/SectionTitle.vue';
+import { formatPeriodDate, toDateTime } from '~/utils/period';
 
 const { t } = useI18n();
 
@@ -63,7 +64,12 @@ defineProps<{
   lang: CVSupportedLangs;
 }>();
 
-const formatPeriod = (from: string, end?: string) => {
-  return end ? `${from} - ${end}` : from;
+const formatPeriod = (
+  from: EducationType['from'],
+  end?: EducationType['end'],
+) => {
+  const fromLabel = formatPeriodDate(from);
+
+  return end ? `${fromLabel} - ${formatPeriodDate(end)}` : fromLabel;
 };
 </script>

--- a/app/components/Experience/Experience.vue
+++ b/app/components/Experience/Experience.vue
@@ -28,7 +28,7 @@
                 </h3>
                 <div class="job-meta">
                   <span class="meta-text">
-                    <time :datetime="job.from" itemprop="datePosted">{{
+                    <time :datetime="toDateTime(job.from)" itemprop="datePosted">{{
                       formatPeriod(job.from, job.end)
                     }}</time>
                     <span class="meta-separator">|</span>
@@ -119,6 +119,10 @@ import './Experience.scss';
 import type { CVSupportedLangs, WorkExperience } from '~/types/cv';
 import InlineLink from '../ui/InlineLink.vue';
 import SectionTitle from '../ui/SectionTitle.vue';
+import {
+  formatPeriod as formatPeriodRange,
+  toDateTime,
+} from '~/utils/period';
 
 const { t } = useI18n();
 
@@ -127,7 +131,8 @@ defineProps<{
   lang: CVSupportedLangs;
 }>();
 
-const formatPeriod = (from: string, end?: string) => {
-  return `${from} - ${end || t('experience.present')}`;
-};
+const formatPeriod = (
+  from: WorkExperience['from'],
+  end?: WorkExperience['end'],
+) => formatPeriodRange(from, end, t('experience.present'));
 </script>

--- a/app/components/StructuredData.vue
+++ b/app/components/StructuredData.vue
@@ -5,6 +5,7 @@
 
 <script setup lang="ts">
 import type { CV } from '~/types/cv';
+import { toIsoDate } from '~/utils/period';
 
 const props = defineProps<{
   cv: CV;
@@ -55,8 +56,8 @@ const structuredData = computed(() => {
       },
       description: job.description[props.lang],
       skills: job.technologies,
-      startDate: job.from,
-      endDate: job.end || undefined,
+      startDate: toIsoDate(job.from),
+      endDate: job.end ? toIsoDate(job.end) : undefined,
     })),
   };
 

--- a/app/types/cv.ts
+++ b/app/types/cv.ts
@@ -43,13 +43,22 @@ export const Technologies = z.object({
   link: z.string(),
 });
 
+export const PeriodDateObjectSchema = z.object({
+  year: z.number().int().optional(),
+  month: z.number().int().min(1).max(12).optional(),
+});
+
+export const PeriodDateSchema = PeriodDateObjectSchema;
+
+export type PeriodDate = z.infer<typeof PeriodDateSchema>;
+
 export const WorkExperienceSchema = z.object({
   title: LocalizedStringSchema,
   company: CompanySchema,
   employmentType: z.string().optional(),
   location: z.string(),
-  from: z.string(),
-  end: z.string().optional(),
+  from: PeriodDateSchema,
+  end: PeriodDateSchema.optional(),
   description: LocalizedStringSchema,
   technologies: z.array(Technologies),
 });
@@ -63,8 +72,8 @@ export const EducationSchema = z.object({
   degree: LocalizedStringSchema,
   institution: InstitutionSchema,
   location: z.string(),
-  from: z.string(),
-  end: z.string().optional(),
+  from: PeriodDateSchema,
+  end: PeriodDateSchema.optional(),
   note: LocalizedStringSchema.optional(),
 });
 

--- a/app/utils/period.ts
+++ b/app/utils/period.ts
@@ -1,0 +1,51 @@
+import type { PeriodDate } from '~/types/cv';
+
+const padMonth = (month: number) => String(month).padStart(2, '0');
+
+export const formatPeriodDate = (date: PeriodDate): string => {
+  const { year, month } = date;
+
+  if (year !== undefined && month !== undefined) {
+    return `${year}-${padMonth(month)}`;
+  }
+
+  if (year !== undefined) {
+    return String(year);
+  }
+
+  if (month !== undefined) {
+    return padMonth(month);
+  }
+
+  return '';
+};
+
+export const formatPeriod = (
+  from: PeriodDate,
+  end: PeriodDate | undefined,
+  presentLabel: string,
+): string => {
+  const fromLabel = formatPeriodDate(from);
+
+  if (!end) {
+    return `${fromLabel} - ${presentLabel}`;
+  }
+
+  return `${fromLabel} - ${formatPeriodDate(end)}`;
+};
+
+export const toDateTime = (date: PeriodDate): string => formatPeriodDate(date);
+
+export const toIsoDate = (date: PeriodDate): string | undefined => {
+  const { year, month } = date;
+
+  if (year !== undefined && month !== undefined) {
+    return `${year}-${padMonth(month)}-01`;
+  }
+
+  if (year !== undefined) {
+    return `${year}-01-01`;
+  }
+
+  return undefined;
+};

--- a/content/example.yaml
+++ b/content/example.yaml
@@ -34,7 +34,8 @@ workExperience:
     company: Ford Motor Company
     companyUrl: https://ford.com
     location: Dearborn, MI
-    from: '2021'
+    from:
+      year: 2021
     description:
       en: >
         Lead mechanical design engineer for next-generation electric vehicle
@@ -67,8 +68,10 @@ workExperience:
       hu: Mechanikai Tervező Mérnök
     company: General Motors
     location: Warren, MI
-    from: '2018'
-    end: '2021'
+    from:
+      year: 2018
+    end:
+      year: 2021
     description:
       en: >
         Designed and developed powertrain components for internal combustion
@@ -100,8 +103,10 @@ workExperience:
       hu: Gyártási Mérnök
     company: Chrysler (Stellantis)
     location: Auburn Hills, MI
-    from: '2015'
-    end: '2018'
+    from:
+      year: 2015
+    end:
+      year: 2018
     description:
       en: >
         Optimized manufacturing processes for automotive assembly lines.
@@ -134,8 +139,10 @@ workExperience:
       hu: Junior Gépészmérnök
     company: BorgWarner
     location: Auburn Hills, MI
-    from: '2012'
-    end: '2015'
+    from:
+      year: 2012
+    end:
+      year: 2015
     description:
       en: >
         Supported design and testing of turbocharger systems for passenger
@@ -171,8 +178,10 @@ educations:
       en: University of Michigan
       hu: Michigan Egyetem
     location: Ann Arbor, MI
-    from: '2010'
-    end: '2012'
+    from:
+      year: 2010
+    end:
+      year: 2012
     note:
       en: 'Thesis: "Optimization of Automotive Cooling Systems" - GPA: 3.8/4.0'
       hu:
@@ -186,8 +195,10 @@ educations:
       en: Michigan State University
       hu: Michigan Egyetem
     location: East Lansing, MI
-    from: '2006'
-    end: '2010'
+    from:
+      year: 2006
+    end:
+      year: 2010
     note:
       en: 'Magna Cum Laude - Tau Beta Pi Engineering Honor Society'
       hu: 'Magna Cum Laude - Tau Beta Pi Mérnöki Tiszteleti Társaság'

--- a/content/gabor-pichner.yaml
+++ b/content/gabor-pichner.yaml
@@ -29,6 +29,84 @@ personal:
 
 workExperience:
   - title:
+      en: Full Stack Developer
+      hu: Full Stack Fejlesztő
+    company:
+      name: it.hu
+      link: https://it.hu
+    employmentType: contract
+    location: Budapest, HU
+    from:
+      year: 2026
+      month: 6
+    end:
+      year: 2026
+      month: 7
+    description:
+      en: >
+        Built a B2B webshop for it.hu, including backend services, frontend,
+        observability stack, and background job processing.
+      hu: >
+        B2B webshop fejlesztése az it.hu számára, backend szolgáltatásokkal,
+        frontenddel, observability stackkel és háttérfolyamat-kezeléssel.
+    technologies:
+      - name: Python
+        link: https://www.python.org/
+      - name: Next.js
+        link: https://nextjs.org/
+      - name: React
+        link: https://react.dev/
+      - name: PostgreSQL
+        link: https://www.postgresql.org/
+      - name: Redis
+        link: https://redis.io/
+      - name: Docker
+        link: https://www.docker.com/
+      - name: Prometheus
+        link: https://prometheus.io/
+      - name: Grafana
+        link: https://grafana.com/
+      - name: Alloy
+        link: https://grafana.com/docs/alloy/
+      - name: Loki
+        link: https://grafana.com/oss/loki/
+      - name: OpenTelemetry
+        link: https://opentelemetry.io/
+      - name: Arq
+        link: https://arq-docs.helpmanual.io/
+
+  - title:
+      en: Full Stack Developer
+      hu: Full Stack Fejlesztő
+    company:
+      name: Elevate Healthcare
+      link: https://elevatehealth.net
+    employmentType: contract
+    location: Veszprém, HU
+    from:
+      year: 2026
+      month: 6
+    end:
+      year: 2026
+      month: 6
+    description:
+      en: >
+        Fixed a security vulnerability using JWKS signing to ensure trusted
+        data transport across the healthcare platform.
+      hu: >
+        Egy sebezhetőség javítása JWKS aláírás használatával a megbízható
+        adatok szállításának biztosításához a healthcare platformon.
+    technologies:
+      - name: Ionic
+        link: https://ionicframework.com/
+      - name: .NET
+        link: https://dotnet.microsoft.com/
+      - name: Angular
+        link: https://angular.io/
+      - name: JWKS
+        link: https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-key-sets
+
+  - title:
       en: Full Stack developer
       hu: Full Stack Fejlesztő
     company:
@@ -36,8 +114,12 @@ workExperience:
       link: https://fizz.hu
     employmentType: contract
     location: Budapest, HU
-    from: "2026"
-    end: "2026"
+    from:
+      year: 2026
+      month: 1
+    end:
+      year: 2026
+      month: 5
     description:
       en: >
         Full-stack Developer in the Advisory team at fizz.hu, 
@@ -75,8 +157,12 @@ workExperience:
       link: https://www.facekom.net
     employmentType: contract
     location: Budapest, HU
-    from: "2025"
-    end: "2025"
+    from:
+      year: 2025
+      month: 8
+    end:
+      year: 2025
+      month: 12
     description:
       en: >
         As a Site Reliability Engineer, I lead reliability and scalability
@@ -111,8 +197,12 @@ workExperience:
       link: https://elevatehealth.net
     employmentType: contract
     location: Veszprém, HU
-    from: "2025"
-    end: "2025"
+    from:
+      year: 2025
+      month: 7
+    end:
+      year: 2025
+      month: 3
     description:
       en: >
         Managed and maintained a production Kubernetes cluster, upgraded and
@@ -155,8 +245,11 @@ workExperience:
       link: https://elevatehealth.net
     employmentType: contract
     location: Veszprém, HU
-    from: "2024"
-    end: "2025"
+    from:
+      year: 2024
+      month: 6
+    end:
+      year: 2025
     description:
       en: >
         Provided strategic architecture and software development consulting,
@@ -183,8 +276,10 @@ workExperience:
       link: https://inwedio.com
     employmentType: contract
     location: Budapest, HU
-    from: "2024"
-    end: "2025"
+    from:
+      year: 2024
+    end:
+      year: 2025
     description:
       en: >
         Contributed to the architecture and feature development of a
@@ -237,8 +332,10 @@ workExperience:
       link: https://placcon.hu
     employmentType: contract
     location: Budapest, HU
-    from: "2024"
-    end: "2025"
+    from:
+      year: 2024
+    end:
+      year: 2025
     description:
       en: >
         Developed a PWA for a restaurant system to replace the previous slower
@@ -272,8 +369,10 @@ workExperience:
       link: https://placcon.hu
     employmentType: contract
     location: Budapest, HU
-    from: "2024"
-    end: "2024"
+    from:
+      year: 2024
+    end:
+      year: 2024
     description:
       en: >
         Developed a billing integration for a restaurant system with
@@ -298,8 +397,10 @@ workExperience:
       name: Emlékkód
     employmentType: contract
     location: Budapest, HU
-    from: "2024"
-    end: "2024"
+    from:
+      year: 2024
+    end:
+      year: 2024
     description:
       en: >
         Developed a complete memorial website portal with login, profile and
@@ -335,8 +436,10 @@ workExperience:
       link: https://placcon.hu
     employmentType: contract
     location: Budapest, HU
-    from: "2023"
-    end: "2024"
+    from:
+      year: 2023
+    end:
+      year: 2024
     description:
       en: >
         Developed a QR code-based payment integration for a restaurant system.
@@ -376,8 +479,10 @@ workExperience:
       link: https://rigortech.hu
     employmentType: contract
     location: Budapest, HU
-    from: "2023"
-    end: "2024"
+    from:
+      year: 2023
+    end:
+      year: 2024
     description:
       en: >
         Created a website for a mechanical engineering company. Later, extended
@@ -409,8 +514,10 @@ workExperience:
       link: https://placcon.hu
     employmentType: contract
     location: Budapest, HU
-    from: "2023"
-    end: "2023"
+    from:
+      year: 2023
+    end:
+      year: 2023
     description:
       en: >
         Developed a serial port and Bluetooth-based cash register integration
@@ -442,8 +549,10 @@ workExperience:
       link: https://placcon.hu
     employmentType: contract
     location: Budapest, HU
-    from: "2022"
-    end: "2023"
+    from:
+      year: 2022
+    end:
+      year: 2023
     description:
       en: >
         Worked on the fiscal printing integration of a restaurant system. The
@@ -485,8 +594,12 @@ workExperience:
       link: https://elevatehealth.net
     employmentType: full-time
     location: Veszprém, HU
-    from: "2022"
-    end: "2024"
+    from:
+      year: 2022
+      month: 6
+    end:
+      year: 2024
+      month: 8
     description:
       en: >
         Promoted from previous role as a senior developer to a lead developer.
@@ -538,8 +651,12 @@ workExperience:
       link: https://elevatehealth.net
     employmentType: full-time
     location: Veszprém, HU
-    from: "2021"
-    end: "2022"
+    from:
+      year: 2021
+      month: 5
+    end:
+      year: 2022
+      month: 6
     description:
       en: >
         During this time at CAE Healthcare Hungary, worked on the LearningSpace
@@ -610,8 +727,12 @@ workExperience:
       link: https://www.cloudstorm.io
     employmentType: full-time
     location: Budapest, HU
-    from: "2018"
-    end: "2021"
+    from:
+      year: 2018
+      month: 4
+    end:
+      year: 2021
+      month: 5
     description:
       en: >
         Used to develop custom RPA solutions, but then started to work on a new
@@ -685,8 +806,12 @@ workExperience:
       link: https://uni-pannon.hu
     employmentType: full-time
     location: Veszprém, HU
-    from: "2018"
-    end: "2018"
+    from:
+      year: 2018
+      month: 2
+    end:
+      year: 2018
+      month: 4
     description:
       en: >
         Developed a map-based research result sharing portal for the Image
@@ -724,8 +849,10 @@ workExperience:
       link: https://uni-pannon.hu
     employmentType: full-time
     location: Veszprém, HU
-    from: "2017"
-    end: "2018"
+    from:
+      year: 2017
+    end:
+      year: 2018
     description:
       en: >
         Design, implementation and operation of a production support solution
@@ -769,8 +896,10 @@ workExperience:
       link: https://it.hu
     employmentType: intern
     location: Veszprém, HU
-    from: "2016"
-    end: "2016"
+    from:
+      year: 2016
+    end:
+      year: 2016
     description:
       en: >
         They deal with IT networking and operation. Developed a full stack
@@ -808,8 +937,10 @@ educations:
         hu: Pannon Egyetem
       link: https://uni-pannon.hu
     location: Veszprém, HU
-    from: "2014"
-    end: "2018"
+    from:
+      year: 2014
+    end:
+      year: 2018
     note:
       en: Excellent
       hu: Kiváló
@@ -822,8 +953,10 @@ educations:
         hu: Ipari Szakközépiskola
       link: https://www.ipariszakkozep.hu
     location: Veszprém, HU
-    from: "2010"
-    end: "2014"
+    from:
+      year: 2010
+    end:
+      year: 2014
 
 skills:
   - name: TypeScript / JavaScript

--- a/content/gabor-pichner.yaml
+++ b/content/gabor-pichner.yaml
@@ -202,7 +202,7 @@ workExperience:
       month: 7
     end:
       year: 2025
-      month: 3
+      month: 10
     description:
       en: >
         Managed and maintained a production Kubernetes cluster, upgraded and
@@ -250,6 +250,7 @@ workExperience:
       month: 6
     end:
       year: 2025
+      month: 3
     description:
       en: >
         Provided strategic architecture and software development consulting,
@@ -278,8 +279,10 @@ workExperience:
     location: Budapest, HU
     from:
       year: 2024
+      month: 1
     end:
       year: 2025
+      month: 12
     description:
       en: >
         Contributed to the architecture and feature development of a
@@ -334,8 +337,10 @@ workExperience:
     location: Budapest, HU
     from:
       year: 2024
+      month: 2
     end:
       year: 2025
+      month: 7
     description:
       en: >
         Developed a PWA for a restaurant system to replace the previous slower
@@ -371,8 +376,10 @@ workExperience:
     location: Budapest, HU
     from:
       year: 2024
+      month: 1
     end:
       year: 2024
+      month: 3
     description:
       en: >
         Developed a billing integration for a restaurant system with
@@ -399,8 +406,10 @@ workExperience:
     location: Budapest, HU
     from:
       year: 2024
+      month: 4
     end:
       year: 2024
+      month: 8
     description:
       en: >
         Developed a complete memorial website portal with login, profile and
@@ -438,8 +447,10 @@ workExperience:
     location: Budapest, HU
     from:
       year: 2023
+      month: 5
     end:
       year: 2024
+      month: 6
     description:
       en: >
         Developed a QR code-based payment integration for a restaurant system.
@@ -481,8 +492,10 @@ workExperience:
     location: Budapest, HU
     from:
       year: 2023
+      month: 10
     end:
       year: 2024
+      month: 2
     description:
       en: >
         Created a website for a mechanical engineering company. Later, extended
@@ -516,8 +529,10 @@ workExperience:
     location: Budapest, HU
     from:
       year: 2023
+      month: 9
     end:
       year: 2023
+      month: 12
     description:
       en: >
         Developed a serial port and Bluetooth-based cash register integration
@@ -551,8 +566,10 @@ workExperience:
     location: Budapest, HU
     from:
       year: 2022
+      month: 4
     end:
       year: 2023
+      month: 3
     description:
       en: >
         Worked on the fiscal printing integration of a restaurant system. The
@@ -851,8 +868,10 @@ workExperience:
     location: Veszprém, HU
     from:
       year: 2017
+      month: 2
     end:
-      year: 2018
+      year: 2017
+      month: 12
     description:
       en: >
         Design, implementation and operation of a production support solution
@@ -898,8 +917,10 @@ workExperience:
     location: Veszprém, HU
     from:
       year: 2016
+      month: 7
     end:
       year: 2016
+      month: 8
     description:
       en: >
         They deal with IT networking and operation. Developed a full stack
@@ -939,8 +960,10 @@ educations:
     location: Veszprém, HU
     from:
       year: 2014
+      month: 9
     end:
       year: 2018
+      month: 1
     note:
       en: Excellent
       hu: Kiváló
@@ -955,8 +978,10 @@ educations:
     location: Veszprém, HU
     from:
       year: 2010
+      month: 9
     end:
       year: 2014
+      month: 6
 
 skills:
   - name: TypeScript / JavaScript

--- a/schema/cv.schema.json
+++ b/schema/cv.schema.json
@@ -14,7 +14,10 @@
               "type": "string"
             }
           },
-          "required": ["en", "hu"],
+          "required": [
+            "en",
+            "hu"
+          ],
           "additionalProperties": false
         },
         "title": {
@@ -35,10 +38,27 @@
                 "type": "string"
               },
               "icon": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                  "dark": {
+                    "type": "string"
+                  },
+                  "light": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "dark",
+                  "light"
+                ],
+                "additionalProperties": false
               }
             },
-            "required": ["platform", "url", "icon"],
+            "required": [
+              "platform",
+              "url",
+              "icon"
+            ],
             "additionalProperties": false
           }
         },
@@ -49,18 +69,32 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["location", "phone", "email", "link"]
+                "enum": [
+                  "location",
+                  "phone",
+                  "email",
+                  "link"
+                ]
               },
               "value": {
                 "type": "string"
               }
             },
-            "required": ["type", "value"],
+            "required": [
+              "type",
+              "value"
+            ],
             "additionalProperties": false
           }
         }
       },
-      "required": ["name", "title", "picture", "links", "contact"],
+      "required": [
+        "name",
+        "title",
+        "picture",
+        "links",
+        "contact"
+      ],
       "additionalProperties": false
     },
     "workExperience": {
@@ -81,7 +115,9 @@
                 "type": "string"
               }
             },
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "additionalProperties": false
           },
           "employmentType": {
@@ -91,10 +127,21 @@
             "type": "string"
           },
           "from": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "year": {
+                "type": "integer"
+              },
+              "month": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 12
+              }
+            },
+            "additionalProperties": false
           },
           "end": {
-            "type": "string"
+            "$ref": "#/properties/workExperience/items/properties/from"
           },
           "description": {
             "$ref": "#/properties/personal/properties/name"
@@ -111,7 +158,10 @@
                   "type": "string"
                 }
               },
-              "required": ["name", "link"],
+              "required": [
+                "name",
+                "link"
+              ],
               "additionalProperties": false
             }
           }
@@ -145,23 +195,30 @@
                 "type": "string"
               }
             },
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "additionalProperties": false
           },
           "location": {
             "type": "string"
           },
           "from": {
-            "type": "string"
+            "$ref": "#/properties/workExperience/items/properties/from"
           },
           "end": {
-            "type": "string"
+            "$ref": "#/properties/workExperience/items/properties/from"
           },
           "note": {
             "$ref": "#/properties/personal/properties/name"
           }
         },
-        "required": ["degree", "institution", "location", "from"],
+        "required": [
+          "degree",
+          "institution",
+          "location",
+          "from"
+        ],
         "additionalProperties": false
       }
     },
@@ -177,7 +234,9 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -193,12 +252,20 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     }
   },
-  "required": ["personal", "workExperience", "educations", "skills", "hobbies"],
+  "required": [
+    "personal",
+    "workExperience",
+    "educations",
+    "skills",
+    "hobbies"
+  ],
   "additionalProperties": false,
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/scripts/generate-llm-config.ts
+++ b/scripts/generate-llm-config.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import type { LLMsSection, ModuleOptions } from 'nuxt-llms';
 import type { SiteConfig } from '../config.types';
 import { CVSchema, type CV, type CVSupportedLangs } from '../app/types/cv';
+import { formatPeriodDate } from '../app/utils/period';
 
 const readCV = async (filename: string): Promise<CV> => {
   const fileContent = await readFile(
@@ -38,7 +39,7 @@ const getSections = (cv: CV): LLMsSection[] => [
     links: cv.workExperience.map(exp => ({
       title: `${translate(exp.title)} at ${exp.company.name} (${exp.location})${exp.employmentType ? ` - ${exp.employmentType}` : ''}`,
       description: `${translate(exp.description)}
-From: ${exp.from}${exp.end ? ` To: ${exp.end}` : ''}
+From: ${formatPeriodDate(exp.from)}${exp.end ? ` To: ${formatPeriodDate(exp.end)}` : ''}
 Technologies: ${exp.technologies.map(tech => tech.name).join(', ')}`,
       href: exp.company.link || '#',
     })),


### PR DESCRIPTION
## Summary
- Introduce explicit `from`/`end` period objects with optional `year` and `month` properties across work experience and education
- Add shared `period` utilities for display, datetime attributes, structured data, and LLM config output
- Update CV content with recent projects (Fizz, Elevate Healthcare, it.hu) and migrate all dates to the new format

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run generate`
- [ ] Verify experience and education date ranges render correctly on the CV page
- [ ] Confirm month-precision entries display as `YYYY-MM` (e.g. Fizz `2026-01 - 2026-05`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CV dates now support more detailed month/year entries across experience and education sections.
  * Generated profile data now uses cleaner, structured date formats for improved consistency.

* **Bug Fixes**
  * Date ranges and “current/present” labels now display more reliably in profile views.
  * Structured profile metadata now uses properly formatted dates for better compatibility with external services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->