### PR TITLE
docs: add AI-native documentation and v2 rewrite plan

### DIFF
--- a/.cursor/rules/cv-workspace.mdc
+++ b/.cursor/rules/cv-workspace.mdc
@@ -1,0 +1,15 @@
+---
+description: CV repo workspace — read docs before coding
+alwaysApply: true
+---
+
+# CV workspace
+
+Before coding, read [`docs/.ai/README.md`](../../docs/.ai/README.md) and load only task-relevant docs.
+
+Quick routing:
+- CV YAML → `docs/.ai/content-model.md`, `docs/.ai/workflows/edit-cv-content.md`
+- UI/SCSS → `docs/.ai/architecture.md`, `docs/.ai/coding-standards.md`
+- CI/release → `docs/.ai/workflows/run-and-verify.md`, `release.md`
+
+Hard rules: minimal diff, no commits unless asked, Mermaid for flow diagrams, no `@apply` in SCSS.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,22 @@
 # Agents
 
-This repository supports task-focused contributors (human or automated) that
-work in small, reviewable changes.
+> **AI-native docs:** Read [`docs/.ai/README.md`](./docs/.ai/README.md) first.
+
+Quick links:
+
+- [Architecture](./docs/.ai/architecture.md)
+- [Coding standards](./docs/.ai/coding-standards.md)
+- [Content model](./docs/.ai/content-model.md)
+- [Workflows](./docs/.ai/workflows/)
+- [Human docs index](./docs/README.md)
 
 ## Recommended agent roles
 
-- Dependency Agent
-  - Updates npm dependencies in controlled batches.
-  - Runs `npm outdated` and applies updates with validation.
-- Quality Agent
-  - Runs local quality gates before opening or updating a PR.
-  - Required checks: `npm ci`, `npm run lint`, `npm run typecheck`,
-    `npm run generate`.
-- CI Agent
-  - Maintains GitHub Actions workflows and keeps checks fast and reliable.
-- Release Agent
-  - Handles release workflow and release automation setup.
+- **Dependency Agent** — npm updates in controlled batches; `npm outdated` +
+  validation.
+- **Quality Agent** — `npm ci`, lint, typecheck, generate before PR.
+- **CI Agent** — GitHub Actions workflows; keep checks fast and reliable.
+- **Release Agent** — semantic-release and publish workflow.
 
 ## Working rules
 
@@ -23,3 +24,5 @@ work in small, reviewable changes.
 - Prefer small commits with clear intent.
 - Commit messages and PR titles must follow Conventional Commits.
 - Keep CI green before requesting review.
+
+See also [`SKILLS.md`](./SKILLS.md).

--- a/README.md
+++ b/README.md
@@ -1,62 +1,61 @@
 # CV – Nuxt
 
-This is a modern, maintainable CV site built with Nuxt, Vue, TypeScript, and
-SCSS.
+Modern, maintainable CV site built with Nuxt 4, Vue 3, TypeScript, and SCSS.
+Content lives in YAML; the site is statically generated.
+
+**Documentation:** [`docs/README.md`](./docs/README.md) · **Agents:**
+[`docs/.ai/README.md`](./docs/.ai/README.md)
 
 ## Setup
 
-Install dependencies:
-
 ```bash
-npm install
+npm ci
+npm run dev    # http://localhost:3000
 ```
 
-## Development Server
-
-Start the development server on `http://localhost:3000`:
-
-```bash
-npm run dev
-```
+See [`docs/setup.md`](./docs/setup.md) for prerequisites and troubleshooting.
 
 ## Production
 
-Build the application for production:
-
 ```bash
-npm run build
-```
-
-Locally preview production build:
-
-```bash
+npm run generate    # static output → .output/public
 npm run preview
 ```
 
-Check out the
-[deployment documentation](https://nuxt.com/docs/getting-started/deployment) for
-more information.
+Deploy: GitHub Pages on `v*` tags, or Docker (`docker compose up` → port 8000).
 
-## End-to-end tests
+## Quality gate
 
-Run Playwright E2E tests:
+```bash
+npm run lint
+npm run typecheck
+npm run generate
+```
+
+## Tests
 
 ```bash
 npm run test:e2e
-```
-
-Open Playwright's interactive runner:
-
-```bash
 npm run test:e2e:ui
+npm run storybook
 ```
 
-## Project Structure & Conventions
+## Edit CV content
 
-This project follows modern Nuxt 3 and Vue 3 best practices for scalability and
-maintainability.
+Edit `content/gabor-pichner.yaml` — see [`docs/content.md`](./docs/content.md).
 
----
+## Project structure
 
-For more, see the [Nuxt 3 documentation](https://nuxt.com/docs) and
-[Vue 3 style guide](https://vuejs.org/style-guide/).
+```
+app/           Vue components, SCSS, types
+content/       CV YAML data
+i18n/          UI translations (en, hu)
+config.ts      Site URL, meta, active CV file
+docs/          Documentation (human + AI-native)
+tests/         Playwright E2E
+```
+
+## Links
+
+- [Nuxt documentation](https://nuxt.com/docs)
+- [Vue style guide](https://vuejs.org/style-guide/)

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,7 +1,7 @@
 # Skills
 
-This repository uses a concise set of skills and responsibilities for agents
-working on code and CI changes.
+Agent skills for this repository. Full context:
+[`docs/.ai/README.md`](./docs/.ai/README.md).
 
 ## Core skills
 

--- a/docs/.ai/README.md
+++ b/docs/.ai/README.md
@@ -1,0 +1,101 @@
+# AI context — CV site
+
+**Entry point for agents.** Read this file first, then load only what the task
+needs.
+
+## Load order
+
+| Priority | File                                         | When                                    |
+| -------- | -------------------------------------------- | --------------------------------------- |
+| 1        | [architecture.md](./architecture.md)         | Always — system map, build, deploy      |
+| 2        | [coding-standards.md](./coding-standards.md) | Before writing code                     |
+| 3        | [content-model.md](./content-model.md)       | Editing CV YAML or i18n                 |
+| 4        | [workflows/](./workflows/)                   | Multi-step tasks                        |
+| 5        | [../projects/](../projects/)                 | Active initiatives (e.g. stack rewrite) |
+
+## Active projects
+
+| Project                                                                     | Status                                                                             |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [next-shadcn-supabase-rewrite](../projects/next-shadcn-supabase-rewrite.md) | planning — Next + shadcn + Supabase; GitHub Pages on `v2`; Supabase webhook deploy |
+
+## Agent roles
+
+| Role                 | Focus                                                          |
+| -------------------- | -------------------------------------------------------------- |
+| **Dependency Agent** | npm updates in controlled batches; `npm outdated` + validation |
+| **Quality Agent**    | `npm ci`, lint, typecheck, generate before PR                  |
+| **CI Agent**         | GitHub Actions workflows — fast, reliable checks               |
+| **Release Agent**    | semantic-release, tag workflow, publish                        |
+
+See also root [`SKILLS.md`](../../SKILLS.md) for working agreements.
+
+## Deep reference (load on demand)
+
+| File                                                       | Scope                           |
+| ---------------------------------------------------------- | ------------------------------- |
+| [../content.md](../content.md)                             | Human-facing CV editing guide   |
+| [../setup.md](../setup.md)                                 | Local dev setup                 |
+| [../references.md](../references.md)                       | URLs, CI secrets, external docs |
+| [workflows/commit-and-pr.md](./workflows/commit-and-pr.md) | Commits and PRs                 |
+| [workflows/release.md](./workflows/release.md)             | Tag-based deploy                |
+
+## Repository map
+
+```
+cv/
+├── app/                    # Nuxt app (single page: app.vue)
+│   ├── components/         # Header, Experience, Education, Skills, Hobbies, ui/
+│   ├── assets/styles/      # SCSS tokens, mixins, Tailwind helpers
+│   └── types/cv.ts         # Zod schema (source of truth)
+├── content/*.yaml          # CV data
+├── i18n/locales/           # UI strings (en, hu)
+├── config.ts               # Site URL, meta, active CV filename
+├── nuxt.config.ts          # Modules, static preset, i18n
+├── tests/                  # Playwright E2E + visual
+├── .github/workflows/      # CI, publish, release
+└── docs/                   # This documentation tree
+```
+
+## Hard rules
+
+- **Flow diagrams → Mermaid** — not ASCII box art in fenced blocks
+  ([coding-standards.md](./coding-standards.md#documentation)).
+- **Minimize diff** — change only what the task requires.
+- **No commits** unless explicitly asked.
+- **No secrets** in git — use GitHub Secrets / env vars.
+- **Match existing patterns** before adding abstractions.
+- **Tailwind sizing in SCSS** — use `tw-spacing()`, `var(--color-*)`,
+  `var(--text-*)` from `_tailwind.scss`; do not use `@apply` in `.scss` files
+  (Tailwind v4 incompatibility).
+
+## Quick facts
+
+|              | Value                                                      |
+| ------------ | ---------------------------------------------------------- |
+| Framework    | Nuxt 4, Vue 3, TypeScript                                  |
+| Output       | Static (`.output/public`) via `npm run generate`           |
+| Node         | ≥ 24.18.0                                                  |
+| Active CV    | `content/gabor-pichner.yaml` (`config.ts` → `cv.filename`) |
+| Locales      | `en` (default), `hu`                                       |
+| Dev URL      | http://localhost:3000                                      |
+| Quality gate | `npm ci` → lint → typecheck → generate                     |
+
+## Task routing
+
+```mermaid
+flowchart TD
+    Start[What are you changing?]
+    Start --> C[CV YAML content]
+    Start --> U[UI / components / styles]
+    Start --> I[i18n UI strings]
+    Start --> T[Tests / CI]
+    Start --> D[Dependencies]
+    Start --> R[Release / deploy]
+    C --> CM[content-model.md + edit-cv-content.md]
+    U --> Arch[architecture.md + coding-standards.md]
+    I --> CM
+    T --> Run[run-and-verify.md]
+    D --> QG[run-and-verify.md quality gate]
+    R --> Rel[release.md]
+```

--- a/docs/.ai/architecture.md
+++ b/docs/.ai/architecture.md
@@ -1,0 +1,113 @@
+# Architecture
+
+## System context
+
+```mermaid
+flowchart TB
+    subgraph build [Build time]
+        YAML[content/*.yaml]
+        Zod[app/types/cv.ts Zod schema]
+        Nuxt[Nuxt generate]
+        YAML --> Zod
+        Zod --> Nuxt
+        Nuxt --> Static[.output/public]
+    end
+
+    subgraph runtime [Static hosting]
+        Static --> GH[GitHub Pages]
+        Static --> Docker[nginx Docker image]
+    end
+
+    subgraph client [Browser]
+        GH --> SPA[Single-page CV]
+        Docker --> SPA
+    end
+```
+
+## Component responsibilities
+
+| Layer                   | Owns                                                 | Does NOT own           |
+| ----------------------- | ---------------------------------------------------- | ---------------------- |
+| **`content/*.yaml`**    | CV data (personal, jobs, education, skills, hobbies) | UI labels, routing     |
+| **`config.ts`**         | Site URL, SEO meta, which CV file to load            | CV field content       |
+| **`i18n/locales/`**     | Section titles, buttons, employment type labels      | CV body text           |
+| **`app/app.vue`**       | Page shell, loading skeleton, data fetch             | Section markup details |
+| **`app/components/*`**  | Section rendering, SCSS                              | Global site config     |
+| **`@nuxt/content`**     | YAML parse + schema validation                       | Visual design          |
+| **Nitro static preset** | Prerender all routes                                 | Server runtime         |
+
+## Request / data flow
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant Nuxt as Nuxt app.vue
+    participant Content as @nuxt/content
+    participant YAML as content/gabor-pichner.yaml
+
+    Browser->>Nuxt: Load /
+    Nuxt->>Content: queryCollection cv
+    Content->>YAML: Parse + validate
+    YAML-->>Content: CvCollectionItem
+    Content-->>Nuxt: cv data
+    Nuxt->>Browser: Render Header, Experience, Education, Skills, Hobbies
+```
+
+No `pages/` directory — `app/app.vue` is the sole entry. i18n uses
+`prefix_except_default` (`/` = en, `/hu` = Hungarian).
+
+## Key paths
+
+| Task             | Path                                                               |
+| ---------------- | ------------------------------------------------------------------ |
+| Change CV data   | `content/gabor-pichner.yaml`                                       |
+| Switch CV file   | `config.ts` → `siteConfig.cv.filename`                             |
+| CV schema        | `app/types/cv.ts`                                                  |
+| Site meta / URL  | `config.ts`                                                        |
+| Global SCSS      | `app/assets/styles/main.scss`, `_variables.scss`, `_tailwind.scss` |
+| Component styles | `app/components/<Name>/<Name>.scss`                                |
+| UI strings       | `i18n/locales/en.json`, `hu.json`                                  |
+| E2E tests        | `tests/`                                                           |
+| CI               | `.github/workflows/ci.yaml`                                        |
+| Deploy           | `.github/workflows/publish.yaml` (on `v*` tag)                     |
+
+## Modules (nuxt.config.ts)
+
+| Module                              | Role                               |
+| ----------------------------------- | ---------------------------------- |
+| `@nuxt/content`                     | YAML collections + Zod validation  |
+| `@nuxt/ui`                          | UCard, UContainer, design system   |
+| `@nuxtjs/i18n`                      | en/hu routing and messages         |
+| `@nuxtjs/sitemap`, `@nuxtjs/robots` | SEO                                |
+| `nuxt-llms`                         | llms.txt generation                |
+| `@nuxt/scripts`                     | Google Analytics (production only) |
+
+## Styling architecture
+
+- **Tailwind v4** via `@nuxt/ui` — utility classes in templates where
+  appropriate.
+- **SCSS** for component-specific styles — use Tailwind theme tokens
+  (`tw-spacing()`, `var(--color-*)`), not `@apply` in `.scss` files.
+- Vite `additionalData` injects `_variables.scss`, `_mixins.scss`,
+  `_tailwind.scss` globally.
+
+## Build and deploy
+
+```mermaid
+flowchart LR
+    Tag[v* git tag] --> Publish[publish.yaml]
+    Publish --> Gen[npm run generate]
+    Gen --> Pages[GitHub Pages]
+    Publish --> Docker[GHCR image]
+    PR[PR to main] --> CI[ci.yaml]
+    CI --> Lint[lint + typecheck + generate]
+    CI --> E2E[Playwright]
+    CI --> LH[Lighthouse]
+    CI --> Percy[Visual regression]
+```
+
+## Static output
+
+- `nitro.preset: 'static'`
+- Production command: `npm run generate` (not `npm run build` for Pages deploy)
+- Preview: `npx serve .output/public` or `npm run preview`

--- a/docs/.ai/coding-standards.md
+++ b/docs/.ai/coding-standards.md
@@ -1,0 +1,104 @@
+# Coding standards
+
+Rules for agents writing code in this repository.
+
+## Universal
+
+| Rule                 | Detail                                                 |
+| -------------------- | ------------------------------------------------------ |
+| Minimal scope        | Smallest correct diff; no drive-by refactors           |
+| Read neighbors       | Match naming, structure, imports in adjacent files     |
+| Comments             | Only non-obvious business or technical rationale       |
+| Tests                | Add only when asked or when changing critical behavior |
+| Commits              | Only when explicitly requested                         |
+| Conventional Commits | PR titles and commit messages                          |
+| Secrets              | Never in git — GitHub Secrets, env vars                |
+
+## Documentation
+
+| Rule          | Detail                                                                                                     |
+| ------------- | ---------------------------------------------------------------------------------------------------------- |
+| Flow diagrams | **Mermaid** (`flowchart`, `sequenceDiagram`) — not ASCII box art in fenced blocks                          |
+| Doc updates   | Architecture change → `architecture.md`; SCSS/Tailwind rules → this file; YAML schema → `content-model.md` |
+
+## Nuxt / Vue
+
+### Structure
+
+```
+app/
+├── app.vue              # Root page — data fetch, layout shell
+├── components/
+│   ├── Header/
+│   ├── Experience/
+│   ├── Education/
+│   ├── Skills/
+│   ├── Hobbies/
+│   └── ui/              # Shared primitives (SectionTitle, InlineLink)
+├── assets/styles/       # Global SCSS partials
+└── types/cv.ts          # Zod schema
+```
+
+### Conventions
+
+- Single-page app — no `pages/` unless routing requirements change.
+- Components: co-located `<Name>.vue` + `<Name>.scss`.
+- Use `@nuxt/ui` components (UCard, UContainer) where already established.
+- `useAsyncData` + `queryCollection('cv')` for content loading in `app.vue`.
+- i18n: `useI18n()` for UI strings; CV content comes from YAML localized fields.
+
+### DO
+
+- Keep components focused on one CV section.
+- Use existing period utils (`~/utils/period`) for date formatting.
+- Run quality gate before PR: `npm ci`, lint, typecheck, generate.
+
+### DON'T
+
+- Upgrade dependencies without being asked (Dependency Agent scope).
+- Use `@apply` in `.scss` files — Tailwind v4 does not process SCSS; use theme
+  tokens or utility classes in templates.
+- Mix CSS and SCSS for the same component.
+- Edit generated files (`schema/cv.schema.json`) by hand — regenerate via build.
+
+## SCSS / Tailwind
+
+Use Tailwind v4 theme tokens in SCSS for consistent sizing:
+
+```scss
+// Spacing: gap-4 → tw-spacing(4)
+gap: tw-spacing(4);
+
+// Colors: text-gray-400 → var(--color-gray-400)
+color: var(--color-gray-400);
+
+// Typography: text-xl → var(--text-xl)
+font-size: var(--text-xl);
+
+// Breakpoints
+@include tw-md {
+  flex-direction: row;
+}
+```
+
+Helpers live in `app/assets/styles/_tailwind.scss` (auto-injected via Vite).
+
+## Content / YAML
+
+- Schema source: `app/types/cv.ts` — update Zod first, then YAML.
+- All user-facing CV text: `en` + `hu` on localized fields.
+- Reference example: `content/example.yaml`.
+
+## CI expectations
+
+PRs to `main` trigger: lint, typecheck, generate, E2E, Lighthouse (SEO ≥100%,
+a11y ≥95%), Percy visual, Docker build validation.
+
+## Key commands
+
+| Task         | Command                                                 |
+| ------------ | ------------------------------------------------------- |
+| Dev          | `npm run dev`                                           |
+| Quality gate | `npm run lint && npm run typecheck && npm run generate` |
+| E2E          | `npm run test:e2e`                                      |
+| Storybook    | `npm run storybook`                                     |

--- a/docs/.ai/content-model.md
+++ b/docs/.ai/content-model.md
@@ -1,0 +1,121 @@
+# Content model
+
+CV data schema, localization, and validation rules.
+
+## Schema source
+
+| File                    | Role                                             |
+| ----------------------- | ------------------------------------------------ |
+| `app/types/cv.ts`       | **Source of truth** — Zod definitions            |
+| `content.config.ts`     | Wires `CVSchema` into `@nuxt/content` collection |
+| `schema/cv.schema.json` | Generated JSON Schema (do not edit manually)     |
+| `content/example.yaml`  | Reference document with all field types          |
+
+## Top-level shape
+
+```typescript
+{
+  personal: Personal,
+  workExperience: WorkExperience[],
+  educations: Education[],
+  skills: Skill[],
+  hobbies: Hobby[],
+}
+```
+
+## Localization
+
+Type: `Record<'en' | 'hu', string>` for user-facing text fields.
+
+| Layer      | Location              | Example                                        |
+| ---------- | --------------------- | ---------------------------------------------- |
+| CV content | `content/*.yaml`      | `title.en`, `title.hu`                         |
+| UI chrome  | `i18n/locales/*.json` | `cv.workExperience`, `experience.technologies` |
+
+Language routing: `prefix_except_default` — English at `/`, Hungarian at `/hu`.
+
+## Field reference
+
+### `personal`
+
+| Field           | Type                                   | Notes                |
+| --------------- | -------------------------------------- | -------------------- |
+| `name`, `title` | LocalizedString                        | Required both langs  |
+| `picture`       | string                                 | Path under `public/` |
+| `links[]`       | platform, url, icon.dark/light         | Social icons         |
+| `contact[]`     | type: location/phone/email/link, value | Header contact row   |
+
+### `workExperience[]`
+
+| Field            | Type                | Notes                                        |
+| ---------------- | ------------------- | -------------------------------------------- |
+| `title`          | LocalizedString     | Job title                                    |
+| `company`        | `{ name, link? }`   | Company name + optional URL                  |
+| `employmentType` | string?             | i18n key under `experience.employmentType.*` |
+| `location`       | string              | City / region                                |
+| `from`           | `{ year, month? }`  | Start date                                   |
+| `end`            | `{ year, month? }`? | Omit = current position                      |
+| `description`    | LocalizedString     | Supports `>` folded blocks                   |
+| `technologies[]` | `{ name, link }`    | Both required in schema                      |
+
+### `educations[]`
+
+| Field         | Type              | Notes                   |
+| ------------- | ----------------- | ----------------------- |
+| `degree`      | LocalizedString   |                         |
+| `institution` | `{ name, link? }` |                         |
+| `location`    | string            |                         |
+| `from`, `end` | PeriodDate        | Same as work experience |
+| `note`        | LocalizedString?  | Optional footnote       |
+
+### `skills[]` / `hobbies[]`
+
+| Field  | Type                                         |
+| ------ | -------------------------------------------- |
+| `name` | string (skills) or LocalizedString (hobbies) |
+| `link` | string?                                      |
+
+> **Note:** `skills[].name` is a plain string in the schema; `hobbies[].name` is
+> localized.
+
+## Period dates
+
+```yaml
+from:
+  year: 2021
+  month: 3 # optional, 1–12
+end:
+  year: 2024 # omit entire `end` for ongoing
+```
+
+Rendered via `~/utils/period` (`formatPeriod`, `toDateTime`).
+
+## Content loading
+
+```typescript
+// app/app.vue
+queryCollection('cv').where('stem', '=', 'gabor-pichner').first();
+```
+
+The `stem` matches the YAML filename without extension. `config.ts` →
+`cv.filename` documents the intended file but the query is currently hardcoded
+to `gabor-pichner` — align both when switching CV files.
+
+## Validation errors
+
+Common Zod failures:
+
+- Missing `en` or `hu` on localized fields
+- `technologies[].link` missing (required in schema)
+- Invalid `contact.type` enum value
+- `month` outside 1–12
+
+Fix YAML, then `npm run generate` to verify.
+
+## Adding schema fields
+
+1. Update `app/types/cv.ts` (Zod)
+2. Update `content/example.yaml` + active CV YAML
+3. Update relevant Vue component if new UI needed
+4. Run typecheck + generate
+5. Update `docs/content.md` if user-facing

--- a/docs/.ai/workflows/README.md
+++ b/docs/.ai/workflows/README.md
@@ -1,0 +1,14 @@
+# Workflows
+
+Step-by-step procedures for agents. Load the one that matches the task.
+
+| Workflow                                   | Use when                                 |
+| ------------------------------------------ | ---------------------------------------- |
+| [local-setup.md](./local-setup.md)         | First-time or broken dev environment     |
+| [edit-cv-content.md](./edit-cv-content.md) | Updating CV YAML or adding a new CV file |
+| [run-and-verify.md](./run-and-verify.md)   | Build, test, quality gate                |
+| [commit-and-pr.md](./commit-and-pr.md)     | User asked to commit or open PR          |
+| [release.md](./release.md)                 | Tag deploy, semantic-release             |
+
+Before any workflow: read [../architecture.md](../architecture.md) to confirm
+scope.

--- a/docs/.ai/workflows/commit-and-pr.md
+++ b/docs/.ai/workflows/commit-and-pr.md
@@ -1,0 +1,48 @@
+# Workflow: commit and PR
+
+## Before commit
+
+Run [run-and-verify.md](./run-and-verify.md) quality gate.
+
+## Commit (only when user asked)
+
+```bash
+git status
+git diff
+git log -3 --oneline   # match commit style
+```
+
+- Conventional Commits format
+- Message via HEREDOC
+- Never `--no-verify`, never amend unless rules allow
+- Do not commit secrets
+
+## Pull request
+
+```bash
+git status
+git diff main...HEAD
+git log main...HEAD --oneline
+```
+
+Create PR with `gh pr create`:
+
+```markdown
+## Summary
+
+- ...
+
+## Test plan
+
+- [ ] npm run lint
+- [ ] npm run typecheck
+- [ ] npm run generate
+- [ ] (if UI) npm run test:e2e
+```
+
+## CI expectations on PR
+
+`ci.yaml` runs: lint, typecheck, generate, Lighthouse, E2E, Percy, Docker build
+validation, commitlint.
+
+Wait for green before requesting review.

--- a/docs/.ai/workflows/edit-cv-content.md
+++ b/docs/.ai/workflows/edit-cv-content.md
@@ -1,0 +1,50 @@
+# Workflow: edit CV content
+
+Human guide: [`../../content.md`](../../content.md)  
+Schema: [../content-model.md](../content-model.md)
+
+## Before editing
+
+1. Read [content-model.md](../content-model.md) for field shapes.
+2. Use `content/example.yaml` as reference.
+3. Confirm active file: `config.ts` → `cv.filename` (default: `gabor-pichner`).
+
+## Edit flow
+
+```mermaid
+flowchart LR
+    Edit[Edit content/*.yaml]
+    Dev[npm run dev]
+    Check[Visual check en + hu]
+    Gen[npm run generate]
+    Edit --> Dev --> Check --> Gen
+```
+
+## Checklist
+
+- [ ] All localized fields have `en` and `hu`
+- [ ] `technologies[].link` present for each item
+- [ ] Period dates valid (`year` required, `month` 1–12 if set)
+- [ ] Asset paths exist under `public/` (pictures, icons)
+- [ ] UI strings unchanged unless needed → `i18n/locales/`
+
+## New CV file (fork)
+
+1. Copy `content/example.yaml` → `content/<slug>.yaml`
+2. Update `config.ts` → `cv.filename: '<slug>'`
+3. Align `app/app.vue` query `stem` with slug (if hardcoded)
+4. Update `config.ts` site meta (title, URL, favicon)
+5. Replace `public/` assets
+
+## Verify
+
+```bash
+npm run dev          # hot reload check
+npm run generate     # schema validation at build
+```
+
+## Do not
+
+- Put UI labels in YAML (use `i18n/locales/`)
+- Edit `schema/cv.schema.json` manually
+- Commit unless user asked

--- a/docs/.ai/workflows/local-setup.md
+++ b/docs/.ai/workflows/local-setup.md
@@ -1,0 +1,34 @@
+# Workflow: local setup
+
+Human guide: [`../../setup.md`](../../setup.md)
+
+## Steps
+
+```bash
+cd /path/to/cv
+nvm use                    # Node 24.18.0
+npm ci
+npm run dev                # http://localhost:3000
+```
+
+## Verify
+
+| Check             | Expected                           |
+| ----------------- | ---------------------------------- |
+| Dev server        | Page loads with CV content         |
+| No console errors | Clean browser console              |
+| Language switch   | `/hu` shows Hungarian UI + content |
+
+## Quality gate (optional on setup)
+
+```bash
+npm run lint
+npm run typecheck
+npm run generate
+```
+
+## Report back
+
+- Node version used
+- Whether dev server started
+- Any errors from install or generate

--- a/docs/.ai/workflows/release.md
+++ b/docs/.ai/workflows/release.md
@@ -1,0 +1,48 @@
+# Workflow: release
+
+## Overview
+
+```mermaid
+flowchart LR
+    Manual[workflow_dispatch release.yaml]
+    Manual --> SR[semantic-release]
+    SR --> Tag[v* tag]
+    Tag --> Pub[publish.yaml]
+    Pub --> Pages[GitHub Pages]
+    Pub --> GHCR[GHCR Docker image]
+```
+
+## Manual release
+
+1. Ensure `main` is green (CI passed).
+2. GitHub Actions → **Release** workflow → `workflow_dispatch`.
+3. Requires `RELEASE_BOT_GITHUB_TOKEN` secret.
+4. semantic-release creates version tag + changelog.
+
+## Tag deploy (automatic after release)
+
+`publish.yaml` triggers on `v*` tags:
+
+- `npm run generate` → deploy `.output/public` to GitHub Pages
+- Build and push multi-arch Docker image to `ghcr.io/95gabor/cv`
+
+## Local preview of production output
+
+```bash
+npm run generate
+npx serve .output/public
+# or
+docker compose up --build   # port 8000
+```
+
+## Versioning
+
+- Tool: semantic-release + Conventional Commits
+- Changelog: `CHANGELOG.md` (auto-updated)
+- Current version: `package.json` → `version`
+
+## Agent rules
+
+- Do not create releases unless explicitly asked.
+- Do not force-push tags.
+- Release Agent owns dependency of release workflow changes.

--- a/docs/.ai/workflows/run-and-verify.md
+++ b/docs/.ai/workflows/run-and-verify.md
@@ -1,0 +1,56 @@
+# Workflow: run and verify
+
+## Quality gate (default)
+
+```bash
+npm ci
+npm run lint
+npm run typecheck
+npm run generate
+```
+
+| Check     | Pass criteria                                            |
+| --------- | -------------------------------------------------------- |
+| Lint      | Exit 0                                                   |
+| Typecheck | Exit 0                                                   |
+| Generate  | Static output in `.output/public`, no YAML schema errors |
+
+## E2E (when UI/routing changed)
+
+```bash
+npm run test:e2e
+```
+
+Interactive debug: `npm run test:e2e:ui`
+
+## Visual regression (when layout/styles changed)
+
+```bash
+# Requires PERCY_TOKEN
+npm run test:e2e:visual
+```
+
+CI runs Percy automatically on PRs.
+
+## Storybook (when ui/ components changed)
+
+```bash
+npm run storybook
+```
+
+## Build warning check
+
+```bash
+npm run build 2>&1 | grep -i warn
+```
+
+Known harmless warnings: VueUse `#__PURE__`, Nuxt sourcemap plugins, npm
+`always-auth` (global config).
+
+## Report back to user
+
+Include:
+
+- Commands run
+- Pass/fail per check
+- Relevant error excerpt if failed

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent instructions
+
+> **Moved to AI-native structure.** Read [`docs/.ai/README.md`](./.ai/README.md)
+> instead.
+
+Quick links:
+
+- [architecture.md](./.ai/architecture.md)
+- [coding-standards.md](./.ai/coding-standards.md)
+- [content-model.md](./.ai/content-model.md)
+- [workflows/](./.ai/workflows/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,58 @@
+# CV site — documentation
+
+This folder is **version-controlled** (git). Agent and developer context lives
+here.
+
+## AI-native context (agents: start here)
+
+```
+docs/.ai/
+├── README.md              ← entry point
+├── architecture.md
+├── coding-standards.md
+├── content-model.md       ← YAML schema, i18n model
+└── workflows/
+    ├── local-setup.md
+    ├── edit-cv-content.md
+    ├── run-and-verify.md
+    ├── commit-and-pr.md
+    └── release.md
+```
+
+**Read first:** [`.ai/README.md`](./.ai/README.md)
+
+## Reference
+
+| Document                         | Purpose                           |
+| -------------------------------- | --------------------------------- |
+| [content.md](./content.md)       | CV YAML editing, fields, examples |
+| [setup.md](./setup.md)           | Local development environment     |
+| [references.md](./references.md) | GitHub, deploy, external links    |
+| [templates/](./templates/)       | Task brief template               |
+| [projects/](./projects/)         | Larger initiatives (when needed)  |
+| [local/](./local/)               | Personal notes (not shared)       |
+
+## Update rules
+
+**Flow diagrams:** use **Mermaid** in new or updated flow docs (not ASCII box
+art). Details:
+[`.ai/coding-standards.md`](./.ai/coding-standards.md#documentation).
+
+| Change type                     | Update in                                   |
+| ------------------------------- | ------------------------------------------- |
+| Architecture, build, deploy     | `.ai/architecture.md`                       |
+| Code style, SCSS/Tailwind rules | `.ai/coding-standards.md`                   |
+| CV YAML schema, i18n            | `.ai/content-model.md` + `content.md`       |
+| New recurring task              | new file in `.ai/workflows/`                |
+| New larger initiative           | `projects/<slug>.md` + `projects/README.md` |
+| Stack rewrite / migration       | `projects/next-shadcn-supabase-rewrite/`    |
+| Agent roles                     | `.ai/README.md` + root `AGENTS.md`          |
+
+## Quick commands
+
+```bash
+npm ci
+npm run dev          # http://localhost:3000
+npm run lint && npm run typecheck && npm run generate
+npm run test:e2e
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,6 @@
+# Architecture
+
+> **Moved to AI-native structure.** Read
+> [`.ai/architecture.md`](./.ai/architecture.md) instead.
+
+Human overview: [`content.md`](./content.md) · Setup: [`setup.md`](./setup.md)

--- a/docs/content.md
+++ b/docs/content.md
@@ -1,0 +1,108 @@
+# Editing CV content
+
+> Agent workflow:
+> [`.ai/workflows/edit-cv-content.md`](./.ai/workflows/edit-cv-content.md)  
+> Schema details: [`.ai/content-model.md`](./.ai/content-model.md)
+
+## Which file to edit?
+
+| File                              | When                                                                |
+| --------------------------------- | ------------------------------------------------------------------- |
+| `content/gabor-pichner.yaml`      | Your CV data (default)                                              |
+| `content/example.yaml`            | Template / reference for another CV                                 |
+| `config.ts` → `cv.filename`       | Which YAML to load (`gabor-pichner` → `content/gabor-pichner.yaml`) |
+| `i18n/locales/en.json`, `hu.json` | UI strings (section titles, buttons) — **not** CV body content      |
+
+## Bilingual model
+
+CV fields use `en` and `hu` keys:
+
+```yaml
+personal:
+  name:
+    en: Gábor Pichner
+    hu: Pichner Gábor
+  title:
+    en: Senior TypeScript Full-Stack Developer
+    hu: Senior TypeScript Full-Stack Fejlesztő
+```
+
+The language switcher uses i18n; content renders the field matching the selected
+locale.
+
+## Main sections
+
+```mermaid
+flowchart TB
+    YAML[content/*.yaml]
+    YAML --> Personal[personal]
+    YAML --> Work[workExperience]
+    YAML --> Edu[educations]
+    YAML --> Skills[skills]
+    YAML --> Hobbies[hobbies]
+    Personal --> App[app.vue → Header]
+    Work --> App2[Experience component]
+    Edu --> App3[Education component]
+    Skills --> App4[Skills component]
+    Hobbies --> App5[Hobbies component]
+```
+
+## Common fields
+
+### Personal (`personal`)
+
+- `picture` — path under `public/` (e.g. `/pictures/avatars/gabor-pichner.png`)
+- `links` — social links with icon pairs (`dark` / `light`)
+- `contact` — `location`, `phone`, `email`, `link` types
+
+### Work experience (`workExperience`)
+
+```yaml
+- title:
+    en: Senior Developer
+    hu: Senior Fejlesztő
+  company:
+    name: Example Ltd
+    link: https://example.com # optional
+  location: Budapest
+  from:
+    year: 2020
+    month: 3 # optional
+  end: # optional — omit for current role
+    year: 2024
+  employmentType: full-time # optional — i18n key
+  description:
+    en: >
+      Multiline text...
+    hu: >
+      Többsoros szöveg...
+  technologies:
+    - name: TypeScript
+      link: https://www.typescriptlang.org
+```
+
+### Education (`educations`)
+
+Same period model (`from` / `end`); `degree` and `institution` are localized.
+
+### Skills and hobbies
+
+- `skills` — `name` + optional `link`
+- `hobbies` — localized `name` + optional `link`
+
+## Validation
+
+Schema source: `app/types/cv.ts` (Zod). On build/content parse errors, check:
+
+1. Every localized field has both `en` and `hu` values
+2. `from.year` is required for experience/education entries
+3. Technology objects: `name` + `link` (link is required in the schema)
+
+Generated JSON Schema: `schema/cv.schema.json` (part of `npm run generate`).
+
+## New CV file (fork)
+
+1. Copy `content/example.yaml` → `content/<slug>.yaml`
+2. `config.ts`: `cv.filename: '<slug>'`
+3. Replace `public/` assets (avatar, favicon)
+4. `npm run dev` — verify

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,6 @@
+# Conventions
+
+> **Moved to AI-native structure.** Read
+> [`.ai/coding-standards.md`](./.ai/coding-standards.md) instead.
+
+Content / YAML rules: [`.ai/content-model.md`](./.ai/content-model.md)

--- a/docs/local/.gitignore
+++ b/docs/local/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/docs/local/README.md
+++ b/docs/local/README.md
@@ -1,0 +1,22 @@
+# Local notes
+
+This subfolder is for **personal / non-shared** content (gitignored).
+
+## Belongs here
+
+- WIP ideas, brainstorming
+- CV content drafts before commit
+- Local test notes
+
+## Does not belong here
+
+- Anything the team/repo should see → `docs/` root or `.ai/`
+- Secrets in plain text → GitHub Secrets / env vars
+
+## Handoff saves (optional)
+
+```
+local/handoffs/YYYY-MM-DD-<slug>.md
+```
+
+Template: [`templates/task-brief.md`](../templates/task-brief.md)

--- a/docs/projects/README.md
+++ b/docs/projects/README.md
@@ -1,0 +1,22 @@
+# Projects
+
+Documentation for larger, multi-step initiatives.
+
+| Project                                                           | Status   | Description                                                  |
+| ----------------------------------------------------------------- | -------- | ------------------------------------------------------------ |
+| [next-shadcn-supabase-rewrite](./next-shadcn-supabase-rewrite.md) | planning | Next + shadcn + Supabase SSG → GitHub Pages (`v2`, **pnpm**) |
+
+## Status values
+
+`planning` → `in-progress` → `review` → `done`
+
+## Adding a new project
+
+1. Create `projects/<slug>.md` (metadata table + goal + acceptance criteria).
+2. Update this README table.
+3. If agent context is needed: link from the Active projects section in
+   `docs/.ai/README.md`.
+
+## Template
+
+See [`templates/task-brief.md`](../templates/task-brief.md).

--- a/docs/projects/next-shadcn-supabase-rewrite.md
+++ b/docs/projects/next-shadcn-supabase-rewrite.md
@@ -1,0 +1,211 @@
+# Next.js + shadcn + Supabase rewrite
+
+## Metadata
+
+| Field             | Value                                                                                                       |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| Slug              | `next-shadcn-supabase-rewrite`                                                                              |
+| Status            | `planning`                                                                                                  |
+| Goal              | Greenfield rewrite: modern React stack, **UI CV editor** (no JSON/YAML for authors), build-time static site |
+| Baseline          | Current Nuxt 4 static site (`main` branch)                                                                  |
+| Work branch       | **`v2`** — rewrite until cutover merge to `main`                                                            |
+| Live URL          | https://95gabor.me                                                                                          |
+| Effort (estimate) | 1–2 weeks focused implementation + CI port                                                                  |
+
+## Summary
+
+Replace the current **Nuxt 4 + YAML + @nuxt/content** architecture with:
+
+| Layer     | Target                                                                         |
+| --------- | ------------------------------------------------------------------------------ |
+| Framework | **Next.js** (App Router)                                                       |
+| UI        | **shadcn/ui** + **Tailwind CSS v4**                                            |
+| Content   | **Supabase** (Postgres + Storage)                                              |
+| Rendering | **SSG** — Supabase fetch at build time → static HTML (`out/`)                  |
+| Deploy    | **GitHub Pages** from `v2` branch; `next build` with `output: 'export'`        |
+| Rebuild   | **Supabase Database Webhook** → GitHub `repository_dispatch` → deploy workflow |
+
+Content must **not** be fetched client-side on the public CV page. Supabase is
+the source of truth for editable data; the production site remains static HTML
+for performance and SEO.
+
+## Why
+
+| Driver           | Detail                                                                         |
+| ---------------- | ------------------------------------------------------------------------------ |
+| Stack alignment  | Next + React ecosystem; shadcn for composable UI                               |
+| Editable content | **Form-based CV editor** → Supabase tables; developers see structured SQL rows |
+| Simpler styling  | Tailwind-only (no SCSS + Tailwind v4 friction)                                 |
+| Keep strengths   | SEO 100%, a11y ≥95%, sitemap, structured data, bilingual `/` + `/hu`           |
+
+## Non-goals (v1 public site)
+
+- **CV Editor UI** shipped in v1 (schema + seed first; editor follows on `v2`)
+- Multi-tenant / multiple CVs per deployment
+- Runtime SSR for the CV page
+- Dropping bilingual support
+- Dropping Lighthouse CI gates
+
+## Target architecture
+
+```mermaid
+flowchart TB
+    subgraph authoring [Authoring]
+        Admin[Future admin UI]
+        Admin --> SB[(Supabase)]
+    end
+
+    subgraph build [Build time]
+        SB -->|fetch CV + site config| Next[Next.js build]
+        Next --> Static[Static HTML / .next static export]
+    end
+
+    subgraph delivery [Delivery]
+        Static --> Pages[GitHub Pages]
+        WH[Supabase DB Webhook] -->|repository_dispatch| CI[GitHub Actions deploy]
+        CI --> Next
+        CI --> Pages
+    end
+
+    subgraph client [Browser]
+        Pages --> User[Visitor]
+    end
+```
+
+See [architecture detail](./next-shadcn-supabase-rewrite/architecture.md).
+
+## Stack decisions
+
+| Choice             | Decision                            | Rationale                                                        |
+| ------------------ | ----------------------------------- | ---------------------------------------------------------------- |
+| Next.js App Router | Yes                                 | `generateStaticParams`, Metadata API, `sitemap.ts` / `robots.ts` |
+| shadcn/ui          | Yes                                 | Accessible primitives; copied into repo; Tailwind-native         |
+| Tailwind CSS v4    | Yes                                 | Required by shadcn; layout + custom sections                     |
+| SCSS               | No                                  | Avoid dual styling pipelines                                     |
+| Supabase           | Yes                                 | Postgres for structured CV; Storage for images                   |
+| Content fetch      | Build time only                     | Parity with current static site performance                      |
+| Static export      | `output: 'export'`                  | Required for GitHub Pages                                        |
+| Rebuild            | Supabase webhook → GitHub           | No ISR; full static rebuild on content change                    |
+| Deploy             | GitHub Pages                        | Keep current hosting; deploy `out/`                              |
+| Work branch        | `v2`                                | Nuxt stays on `main` until cutover                               |
+| E2E                | Playwright                          | Port existing tests; smoke + locale switch                       |
+| Supabase schema    | **Editor-first hybrid**             | Child tables + `_en`/`_hu` columns; no document JSONB            |
+| Package manager    | **pnpm**                            | On `v2`; `main` stays npm until cutover                          |
+| Local Supabase     | **CLI + Docker** (`supabase start`) | Dev/build against localhost; cloud for CI/prod                   |
+| i18n               | `next-intl` or App Router locales   | Match `prefix_except_default` (`/` en, `/hu` hu)                 |
+
+## Decisions (locked)
+
+| #   | Topic           | Decision                                                                                                                            |
+| --- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Deploy target   | **GitHub Pages**                                                                                                                    |
+| 2   | Repo strategy   | **`v2` branch** until cutover merge to `main`                                                                                       |
+| 3   | Rebuild trigger | **Supabase Database Webhook → GitHub `repository_dispatch`**                                                                        |
+| 4   | E2E testing     | **Playwright** (keep current tooling)                                                                                               |
+| 5   | Supabase schema | **Editor-first hybrid** — tables + `_en`/`_hu` columns; see [supabase-schema.md](./next-shadcn-supabase-rewrite/supabase-schema.md) |
+| 6   | Package manager | **pnpm** (`pnpm-lock.yaml`, `packageManager` in `package.json`)                                                                     |
+| 7   | Local Supabase  | **Self-hosted** via Supabase CLI + Docker; cloud for CI/prod                                                                        |
+
+Detail: [deploy.md](./next-shadcn-supabase-rewrite/deploy.md) ·
+[local-supabase.md](./next-shadcn-supabase-rewrite/local-supabase.md).
+
+## Content authoring goal
+
+| User      | Interface                                                           |
+| --------- | ------------------------------------------------------------------- |
+| CV owner  | Visual editor — forms, lists, uploads, EN/HU fields                 |
+| Developer | Supabase SQL / typed `lib/cv/map-from-db.ts` — no opaque JSON blobs |
+| Visitor   | Static HTML — unchanged performance model                           |
+
+## SEO / quality parity
+
+Must meet or exceed current CI thresholds:
+
+| Metric          | Current gate                                | Target                                      |
+| --------------- | ------------------------------------------- | ------------------------------------------- |
+| Lighthouse SEO  | ≥ 100%                                      | ≥ 100%                                      |
+| Lighthouse a11y | ≥ 95%                                       | ≥ 95%                                       |
+| Structured data | JSON-LD Person + JobPosting                 | Port 1:1                                    |
+| Meta            | title, description, keywords, OG, canonical | Metadata API                                |
+| sitemap.xml     | `@nuxtjs/sitemap`                           | `app/sitemap.ts`                            |
+| robots.txt      | `@nuxtjs/robots`                            | `app/robots.ts`                             |
+| llms.txt        | `nuxt-llms`                                 | Static route or `public/llms.txt` generator |
+| Analytics       | GA production only                          | `@next/third-parties` or equivalent         |
+
+Full checklist: [seo-parity.md](./next-shadcn-supabase-rewrite/seo-parity.md).
+
+## Data model
+
+Supabase replaces `content/*.yaml`. Proposed schema maps current Zod types:
+
+- `site_config`, `cv_profiles`, child tables — see
+  [supabase-schema.md](./next-shadcn-supabase-rewrite/supabase-schema.md)
+
+Detail: [supabase-schema.md](./next-shadcn-supabase-rewrite/supabase-schema.md).
+
+## Migration path
+
+```mermaid
+flowchart LR
+    P0[Phase 0 Planning] --> P1[Phase 1 Scaffold]
+    P1 --> P2[Phase 2 Supabase + seed]
+    P2 --> P3[Phase 3 UI port]
+    P3 --> P4[Phase 4 SEO + i18n]
+    P4 --> P5[Phase 5 CI + cutover]
+```
+
+Phases: [phases.md](./next-shadcn-supabase-rewrite/phases.md).
+
+## Acceptance criteria
+
+- [ ] Next.js app builds static output with CV data from Supabase (no client
+      fetch on `/` or `/hu`)
+- [ ] Visual parity with current sections: Header, Experience, Education,
+      Skills, Hobbies
+- [ ] Bilingual routing: `/` (en), `/hu` (hu)
+- [ ] Lighthouse CI: SEO 100%, a11y ≥ 95%
+- [ ] sitemap.xml, robots.txt, canonical, OG tags, JSON-LD present
+- [ ] `llms.txt` available
+- [ ] GA loads in production only
+- [ ] Local dev: `supabase start` + `.env.local` → build against
+      `http://127.0.0.1:54321` (see
+      [local-supabase.md](./next-shadcn-supabase-rewrite/local-supabase.md))
+- [ ] YAML migrated to **structured** Supabase tables (not a single JSON
+      document)
+- [ ] `lib/cv/map-from-db.ts` maps DB rows → existing `CV` TypeScript shape
+- [ ] CI: lint, typecheck, build, **Playwright** E2E (smoke), Lighthouse
+- [ ] Deploy to GitHub Pages from `out/` on `v2` branch
+- [ ] Supabase webhook triggers deploy workflow on content change
+- [ ] `docs/.ai/architecture.md` updated after cutover
+
+## Risks
+
+| Risk                         | Mitigation                                                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Supabase outage blocks build | Cache last-good export in CI artifact; document local seed fallback                                                 |
+| SEO regression               | seo-parity checklist + Lighthouse gate before cutover                                                               |
+| i18n routing differences     | E2E tests for `/` and `/hu`                                                                                         |
+| Scope creep (admin UI)       | Defer admin to post-v1                                                                                              |
+| GitHub Pages + Next          | `output: 'export'`, `images.unoptimized`, deploy `out/` — see [deploy.md](./next-shadcn-supabase-rewrite/deploy.md) |
+| Webhook spam on bulk edit    | CI `concurrency` cancel-in-progress; optional `updated_at` trigger                                                  |
+
+## Related docs
+
+| Document                                                                | Purpose                                     |
+| ----------------------------------------------------------------------- | ------------------------------------------- |
+| [architecture.md](./next-shadcn-supabase-rewrite/architecture.md)       | Folder layout, data flow, env vars          |
+| [supabase-schema.md](./next-shadcn-supabase-rewrite/supabase-schema.md) | Tables, RLS, seed from YAML                 |
+| [seo-parity.md](./next-shadcn-supabase-rewrite/seo-parity.md)           | Current → Next mapping                      |
+| [phases.md](./next-shadcn-supabase-rewrite/phases.md)                   | Implementation phases                       |
+| [deploy.md](./next-shadcn-supabase-rewrite/deploy.md)                   | GitHub Pages, `v2` branch, Supabase webhook |
+| [local-supabase.md](./next-shadcn-supabase-rewrite/local-supabase.md)   | Self-hosted local Supabase (CLI + Docker)   |
+| [../content.md](../content.md)                                          | Current YAML model (baseline)               |
+| [../.ai/content-model.md](../.ai/content-model.md)                      | Current Zod schema                          |
+
+## Agent quick start
+
+```
+Read docs/projects/next-shadcn-supabase-rewrite.md and the linked folder docs.
+Task: <phase or sub-task>
+Constraints: build-time Supabase fetch only; keep SEO gates; shadcn + Tailwind (no SCSS).
+```

--- a/docs/projects/next-shadcn-supabase-rewrite/README.md
+++ b/docs/projects/next-shadcn-supabase-rewrite/README.md
@@ -1,0 +1,16 @@
+# Next + shadcn + Supabase rewrite — index
+
+| Document                                                                 | Purpose                                               |
+| ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| [../next-shadcn-supabase-rewrite.md](../next-shadcn-supabase-rewrite.md) | **Project brief** — goals, acceptance criteria, risks |
+| [architecture.md](./architecture.md)                                     | Target folder layout, rendering, env vars             |
+| [supabase-schema.md](./supabase-schema.md)                               | Postgres tables, RLS, seed strategy                   |
+| [seo-parity.md](./seo-parity.md)                                         | Nuxt → Next SEO mapping + verification                |
+| [phases.md](./phases.md)                                                 | Implementation phases 0–6                             |
+| [deploy.md](./deploy.md)                                                 | **GitHub Pages**, `v2` branch, cloud webhook          |
+| [local-supabase.md](./local-supabase.md)                                 | Self-hosted local dev (Supabase CLI + Docker)         |
+
+**Status:** `planning`
+
+**Locked decisions:** GitHub Pages · `v2` · Supabase webhook · Playwright ·
+editor-first schema · pnpm · **local Supabase CLI**

--- a/docs/projects/next-shadcn-supabase-rewrite/architecture.md
+++ b/docs/projects/next-shadcn-supabase-rewrite/architecture.md
@@ -1,0 +1,202 @@
+# Target architecture — Next + shadcn + Supabase
+
+## System context
+
+```mermaid
+flowchart TB
+    subgraph supabase [Supabase]
+        PG[(Postgres)]
+        ST[Storage cv-assets]
+    end
+
+    subgraph next [Next.js App Router]
+        Layout[app/layout.tsx]
+        PageEN[app/page.tsx]
+        PageHU[app/hu/page.tsx]
+        Lib[lib/supabase/server.ts]
+        Components[components/ + components/ui/]
+        Layout --> PageEN
+        Layout --> PageHU
+        PageEN --> Lib
+        PageHU --> Lib
+        Lib --> PG
+        PageEN --> Components
+    end
+
+    subgraph seo [SEO layer]
+        Meta[generateMetadata]
+        Sitemap[app/sitemap.ts]
+        Robots[app/robots.ts]
+        JSONLD[components/structured-data.tsx]
+    end
+
+    PageEN --> Meta
+    PageEN --> JSONLD
+```
+
+## Proposed folder layout
+
+```
+cv/                          # rewrite on `v2` branch
+├── app/
+│   ├── layout.tsx           # fonts, theme provider, global shell
+│   ├── page.tsx             # EN CV (default locale)
+│   ├── hu/
+│   │   └── page.tsx         # HU CV (or [locale] dynamic segment)
+│   ├── sitemap.ts
+│   ├── robots.ts
+│   ├── llms.txt/route.ts    # or public/llms.txt
+│   └── globals.css          # Tailwind + shadcn CSS variables
+├── components/
+│   ├── ui/                  # shadcn primitives (button, card, badge, …)
+│   ├── header.tsx
+│   ├── experience.tsx
+│   ├── education.tsx
+│   ├── skills.tsx
+│   ├── hobbies.tsx
+│   ├── language-selector.tsx
+│   ├── structured-data.tsx
+│   └── cookie-consent.tsx
+├── lib/
+│   ├── supabase/
+│   │   ├── server.ts        # service role / anon for build
+│   │   └── types.ts         # generated Database types
+│   ├── cv/
+│   │   ├── fetch.ts         # getCvProfile(slug, locale)
+│   │   └── types.ts         # CV domain types (from current Zod)
+│   └── site-config.ts
+├── messages/
+│   ├── en.json
+│   └── hu.json
+├── public/
+│   └── grid.svg             # static assets not in Supabase Storage
+├── supabase/
+│   ├── config.toml
+│   ├── migrations/
+│   └── seed.sql
+├── tests/                   # Playwright
+├── docs/
+└── next.config.ts
+```
+
+## Rendering strategy
+
+### Build-time fetch (required)
+
+```typescript
+// lib/cv/fetch.ts — called from Server Components at build time
+export async function getCvProfile(slug: string, locale: 'en' | 'hu') {
+  const supabase = createBuildClient();
+  const { data, error } = await supabase
+    .from('cv_profiles')
+    .select('*, work_experiences(*), educations(*), skills(*), hobbies(*)')
+    .eq('slug', slug)
+    .single();
+  if (error) throw error;
+  return mapToCvModel(data, locale);
+}
+```
+
+```typescript
+// app/page.tsx
+export const dynamic = 'force-static'; // or default static with generateStaticParams
+
+export default async function Page() {
+  const cv = await getCvProfile('gabor-pichner', 'en');
+  return <CvPage cv={cv} locale="en" />;
+}
+```
+
+### Rebuild on content change
+
+| Trigger                | Action                                                                           |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| Supabase DB row change | Webhook → GitHub `repository_dispatch` (`supabase-cv-updated`) → deploy workflow |
+| Push to `v2`           | Deploy workflow (during migration)                                               |
+| Manual                 | `workflow_dispatch` on deploy workflow                                           |
+| Tag `v*`               | Release deploy (post-cutover, optional)                                          |
+
+Full setup: [deploy.md](./deploy.md).
+
+Do **not** use `dynamic = 'force-dynamic'` for the public CV route.
+
+## Static export (GitHub Pages)
+
+| Setting              | Value                       |
+| -------------------- | --------------------------- |
+| `output`             | `'export'`                  |
+| `images.unoptimized` | `true`                      |
+| Build output         | `out/`                      |
+| Hosting              | GitHub Pages via Actions    |
+| Branch               | `v2` until cutover → `main` |
+
+Vercel / ISR: **not in scope** (decision locked).
+
+## Environment variables
+
+| Variable                    | Scope                  | Purpose                                                           |
+| --------------------------- | ---------------------- | ----------------------------------------------------------------- |
+| `NEXT_PUBLIC_SITE_URL`      | Build + client         | Canonical, OG, JSON-LD                                            |
+| `SUPABASE_URL`              | Build                  | Supabase project URL                                              |
+| `SUPABASE_SERVICE_ROLE_KEY` | Build only (CI secret) | Full read for static generation                                   |
+| `NEXT_PUBLIC_GA_ID`         | Production             | Analytics                                                         |
+| `SUPABASE_ANON_KEY`         | Future admin only      | Not needed for public static build if using service role at build |
+
+Never expose service role key to the browser.
+
+### Local vs cloud URLs
+
+| Environment     | `SUPABASE_URL`              | Docs                                     |
+| --------------- | --------------------------- | ---------------------------------------- |
+| Local dev       | `http://127.0.0.1:54321`    | [local-supabase.md](./local-supabase.md) |
+| CI / production | `https://<ref>.supabase.co` | GitHub Secrets                           |
+
+## i18n
+
+**Target:** match current `prefix_except_default`.
+
+| URL   | Locale | Content                               |
+| ----- | ------ | ------------------------------------- |
+| `/`   | `en`   | `cv.*.en` fields + `messages/en.json` |
+| `/hu` | `hu`   | `cv.*.hu` fields + `messages/hu.json` |
+
+Options:
+
+1. **`next-intl`** with `[locale]` segment — recommended for UI strings
+2. Duplicate `app/page.tsx` + `app/hu/page.tsx` — minimal, works for two locales
+
+## Styling
+
+```
+Tailwind v4 (globals.css)
+  └── shadcn/ui theme tokens (--background, --primary, …)
+        └── Section components (Tailwind utilities only)
+```
+
+No SCSS. Port design tokens from `app/assets/styles/_variables.scss` to shadcn
+CSS variables.
+
+## CI (target)
+
+**Package manager:** pnpm — `pnpm install --frozen-lockfile` in CI; lockfile
+`pnpm-lock.yaml`.
+
+| Job        | Command                                                         |
+| ---------- | --------------------------------------------------------------- |
+| Install    | `pnpm install --frozen-lockfile`                                |
+| Lint       | `pnpm run lint`                                                 |
+| Typecheck  | `pnpm run typecheck`                                            |
+| Build      | `pnpm run build` (with Supabase secrets)                        |
+| E2E        | `pnpm exec playwright test` against `out/` via `pnpm dlx serve` |
+| Lighthouse | Same thresholds as `.lighthouserc.json`                         |
+
+Local quality gate:
+`pnpm install && pnpm run lint && pnpm run typecheck && pnpm run build`.
+
+## Cutover
+
+1. Lighthouse + E2E green on `v2` branch
+2. Merge `v2` → `main`
+3. Update deploy workflow branch triggers (`v2` → `main`)
+4. GitHub Pages continues via Actions; custom domain unchanged
+5. Archive Nuxt code; update `docs/.ai/architecture.md`

--- a/docs/projects/next-shadcn-supabase-rewrite/deploy.md
+++ b/docs/projects/next-shadcn-supabase-rewrite/deploy.md
@@ -1,0 +1,221 @@
+# Deploy — GitHub Pages, `v2` branch, Supabase webhook
+
+## Decisions (locked)
+
+| Topic           | Decision                                                     |
+| --------------- | ------------------------------------------------------------ |
+| Hosting         | **GitHub Pages** — static HTML only                          |
+| Branch          | **`v2`** — all rewrite work until cutover                    |
+| Content rebuild | **Supabase Database Webhook → GitHub `repository_dispatch`** |
+| Next output     | `output: 'export'` → deploy `out/` directory                 |
+| Package manager | **pnpm** on `v2` (`pnpm-lock.yaml`)                          |
+
+## End-to-end flow
+
+```mermaid
+sequenceDiagram
+    participant Editor as Content editor
+    participant SB as Supabase Postgres
+    participant WH as Supabase Database Webhook
+    participant GH as GitHub API
+    participant CI as GitHub Actions
+    participant Pages as GitHub Pages
+
+    Editor->>SB: UPDATE cv / experiences / …
+    SB->>WH: Row change event
+    WH->>GH: POST repository_dispatch
+    GH->>CI: Trigger deploy workflow
+    CI->>SB: Fetch CV (build time, service role)
+    CI->>CI: next build → out/
+    CI->>Pages: upload-pages-artifact + deploy
+    Pages->>Editor: Live site updated
+```
+
+Manual fallback: `workflow_dispatch` on the same deploy workflow.
+
+## GitHub Pages + Next.js static export
+
+### `next.config.ts`
+
+```typescript
+const nextConfig = {
+  output: 'export',
+  images: { unoptimized: true }, // required for static export
+  // basePath: only if site is served from subpath (not needed for 95gabor.me root)
+};
+```
+
+### Build output
+
+| Current (Nuxt)                                       | Target (Next)                          |
+| ---------------------------------------------------- | -------------------------------------- |
+| `npm run generate` → `.output/public` (Nuxt, `main`) | `pnpm run build` → `out/` (Next, `v2`) |
+
+### Custom domain
+
+Keep existing `95gabor.me` → GitHub Pages CNAME. No `basePath` when deploying to
+domain root.
+
+### GitHub Pages settings (repo)
+
+| Setting           | Value                                               |
+| ----------------- | --------------------------------------------------- |
+| Source            | GitHub Actions                                      |
+| Production branch | `v2` (during migration); `main` after cutover merge |
+
+## `v2` branch strategy
+
+```mermaid
+flowchart LR
+    main[main — Nuxt baseline]
+    v2[v2 — Next rewrite]
+    main -->|cutover merge| v2
+    v2 -->|deploy| Pages[GitHub Pages]
+```
+
+| Phase        | `main`                          | `v2`                                |
+| ------------ | ------------------------------- | ----------------------------------- |
+| Rewrite      | Unchanged Nuxt; live production | Next + Supabase; CI + Pages preview |
+| Cutover      | Merge `v2` → `main`             | Becomes production source           |
+| Post-cutover | Next stack; tag releases        | Delete or keep as archive           |
+
+### CI during migration
+
+- **PRs target `v2`** (not `main`) for rewrite work
+- `main` keeps existing Nuxt CI until cutover
+- Optional: deploy Pages preview only from `v2` pushes
+
+### Cutover checklist
+
+1. Lighthouse + E2E green on `v2`
+2. Merge `v2` → `main`
+3. Update workflows: default branch triggers, Pages deploy branch
+4. Tag `v*` release on `main`
+5. Archive/remove Nuxt app code in follow-up PR if desired
+
+## Supabase → GitHub webhook
+
+### Supabase side
+
+Create **Database Webhooks** (Dashboard → Database → Webhooks) on tables that
+affect the public CV:
+
+| Table              | Events                 |
+| ------------------ | ---------------------- |
+| `site_config`      | INSERT, UPDATE, DELETE |
+| `cv_profiles`      | INSERT, UPDATE, DELETE |
+| `work_experiences` | INSERT, UPDATE, DELETE |
+| `educations`       | INSERT, UPDATE, DELETE |
+| `skills`           | INSERT, UPDATE, DELETE |
+| `hobbies`          | INSERT, UPDATE, DELETE |
+
+Alternatively: one webhook on `cv_profiles` only if child tables always update
+`cv_profiles.updated_at` via trigger (simpler, fewer webhooks).
+
+**Webhook HTTP request:**
+
+```
+POST https://api.github.com/repos/95gabor/cv/dispatches
+Authorization: Bearer <GITHUB_PAT_OR_APP_TOKEN>
+Accept: application/vnd.github+json
+Content-Type: application/json
+
+{
+  "event_type": "supabase-cv-updated",
+  "client_payload": {
+    "table": "{{ table }}",
+    "type": "{{ type }}"
+  }
+}
+```
+
+Store the GitHub token in Supabase **Vault** or webhook secret header — never
+commit.
+
+### GitHub side
+
+New workflow `.github/workflows/deploy-pages.yml` (on `v2`, later `main`):
+
+```yaml
+name: Deploy Pages
+
+on:
+  repository_dispatch:
+    types: [supabase-cv-updated]
+  workflow_dispatch:
+  push:
+    branches: [v2] # remove or change to main after cutover
+    tags: ['v*']
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment: github-pages
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NEXT_PUBLIC_SITE_URL: https://95gabor.me
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: out
+      - uses: actions/deploy-pages@v5
+```
+
+### GitHub secrets required
+
+| Secret                      | Used by                                  |
+| --------------------------- | ---------------------------------------- |
+| `SUPABASE_URL`              | Build fetch                              |
+| `SUPABASE_SERVICE_ROLE_KEY` | Build fetch (CI only)                    |
+| `GITHUB_TOKEN` or PAT       | Supabase webhook → `repository_dispatch` |
+
+For `repository_dispatch`, the token needs `contents` + `actions` scope (classic
+PAT) or fine-grained repo **Contents: Read and write** + **Actions: Read and
+write**.
+
+### Debouncing (optional)
+
+CV edits may fire multiple webhooks (bulk update). Options:
+
+- Supabase trigger: bump single `cv_profiles.updated_at` once per transaction
+- GitHub Actions `concurrency: group: pages-deploy, cancel-in-progress: true` —
+  only latest deploy runs
+
+## Lighthouse CI on `v2`
+
+Update `.lighthouserc.json`:
+
+```json
+"startServerCommand": "npx --yes serve out -p 4173 -a 127.0.0.1"
+```
+
+## Docker (optional, post-cutover)
+
+Current `publish.yaml` builds Docker from Nuxt `generate`. After rewrite:
+
+- Dockerfile serves `out/` via nginx (same pattern as today)
+- Keep tag-triggered Docker publish if still needed
+
+## Related
+
+- [architecture.md](./architecture.md) — app structure
+- [phases.md](./phases.md) — Phase 5–6 deploy tasks
+- [../next-shadcn-supabase-rewrite.md](../next-shadcn-supabase-rewrite.md) —
+  project brief

--- a/docs/projects/next-shadcn-supabase-rewrite/local-supabase.md
+++ b/docs/projects/next-shadcn-supabase-rewrite/local-supabase.md
@@ -1,0 +1,215 @@
+# Local Supabase — self-hosted dev stack
+
+## Decision
+
+| Environment         | Supabase                                            | Purpose                                  |
+| ------------------- | --------------------------------------------------- | ---------------------------------------- |
+| **Local dev**       | **Self-hosted** via Supabase CLI (`supabase start`) | Schema, seed, editor dev, offline builds |
+| **CI / production** | **Supabase Cloud** project                          | Build fetch, webhooks → GitHub deploy    |
+
+Local stack runs in **Docker** on the developer machine — same Postgres + Auth +
+Storage APIs as cloud, without hitting a remote project during day-to-day work.
+
+Production self-hosting (own VPS/K8s) is **out of scope** for v1; cloud Supabase
+for staging/prod.
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph local [Local machine]
+        CLI[Supabase CLI]
+        Docker[Docker Compose]
+        CLI --> Docker
+        Docker --> PG[(Postgres :54322)]
+        Docker --> Studio[Studio :54323]
+        Docker --> API[Kong API :54321]
+        NextDev[pnpm dev / build]
+        NextDev -->|SUPABASE_URL local| API
+    end
+
+    subgraph cloud [Supabase Cloud]
+        CloudPG[(Postgres)]
+        WH[Database Webhook]
+    end
+
+    subgraph ci [GitHub Actions]
+        Build[pnpm run build]
+        WH -->|repository_dispatch| Build
+        Build -->|SUPABASE_URL cloud| CloudPG
+    end
+```
+
+## Prerequisites
+
+| Tool         | Notes                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------- |
+| Docker       | Running daemon (Docker Desktop or colima)                                                     |
+| Supabase CLI | `brew install supabase/tap/supabase` or [install guide](https://supabase.com/docs/guides/cli) |
+| Node.js      | ≥ 24 (Next build)                                                                             |
+| pnpm         | see project brief                                                                             |
+
+## Repo layout
+
+```
+supabase/
+├── config.toml          # CLI config (ports, auth, storage)
+├── migrations/          # SQL migrations (schema)
+├── seed.sql             # optional seed (or scripts/seed.ts)
+└── .gitignore           # ignore .branches, temp — commit migrations + seed
+```
+
+`config.toml` and migrations are **version-controlled**. Local data is ephemeral
+(`db reset`).
+
+## Quick start
+
+```bash
+# once per machine
+supabase login          # only needed for link/deploy to cloud
+
+# in repo root (v2 branch)
+supabase init           # if not already present
+supabase start          # pulls images, starts stack
+
+supabase status         # prints API URL, keys, Studio URL
+```
+
+Typical local URLs (default):
+
+| Service  | URL                                                       |
+| -------- | --------------------------------------------------------- |
+| API      | `http://127.0.0.1:54321`                                  |
+| Studio   | `http://127.0.0.1:54323`                                  |
+| Postgres | `postgresql://postgres:postgres@127.0.0.1:54322/postgres` |
+
+## Environment files
+
+```bash
+# .env.local (gitignored) — local self-hosted
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_SERVICE_ROLE_KEY=<from supabase status>
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+```
+
+```bash
+# CI / production — Supabase Cloud (GitHub Secrets)
+SUPABASE_URL=https://<project-ref>.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=<cloud service role>
+NEXT_PUBLIC_SITE_URL=https://95gabor.me
+```
+
+Never commit service role keys. Add `.env.local` to `.gitignore`.
+
+### Example `package.json` scripts
+
+```json
+{
+  "scripts": {
+    "db:start": "supabase start",
+    "db:stop": "supabase stop",
+    "db:reset": "supabase db reset",
+    "db:status": "supabase status",
+    "db:types": "supabase gen types typescript --local > lib/supabase/types.ts"
+  }
+}
+```
+
+## Workflow
+
+### Schema changes
+
+```bash
+supabase migration new create_cv_tables
+# edit supabase/migrations/<timestamp>_create_cv_tables.sql
+supabase db reset              # apply migrations + seed locally
+pnpm run db:types              # regenerate TS types
+```
+
+### Seed from YAML
+
+```bash
+pnpm run db:seed               # custom script: content/gabor-pichner.yaml → SQL insert
+supabase db reset              # or rely on seed.sql
+```
+
+### Next.js dev / build against local Supabase
+
+```bash
+supabase start
+pnpm run dev                   # fetch uses .env.local → local API
+pnpm run build                 # verify static build with local data
+```
+
+Build-time fetch is identical — only `SUPABASE_URL` and key change.
+
+## Studio (local CMS preview)
+
+Open **Studio** (`http://127.0.0.1:54323`) to browse/edit tables before the CV
+Editor UI exists.
+
+Useful for:
+
+- Verifying seed data structure
+- Manual content edits during development
+- Testing RLS policies
+
+## Webhooks — local vs cloud
+
+|                           | Local self-hosted                          | Cloud              |
+| ------------------------- | ------------------------------------------ | ------------------ |
+| Database Webhook → GitHub | ❌ Not practical (localhost not reachable) | ✅ Production path |
+| Rebuild after edit        | Manual: `pnpm run build` or push to cloud  | Auto via webhook   |
+
+Local content changes do **not** trigger GitHub deploy. That is expected.
+
+Optional: after editing locally, `supabase db push` or seed export to sync cloud
+— document when staging project exists.
+
+## Linking local to cloud (optional)
+
+When a cloud project exists:
+
+```bash
+supabase link --project-ref <ref>
+supabase db push             # push migrations to cloud
+supabase db pull             # pull remote schema (careful)
+```
+
+Use **migrations in git** as source of truth; avoid `db pull` overwriting
+intentional schema.
+
+## Storage (local)
+
+`supabase start` includes local Storage. Bucket `cv-assets` defined in migration
+or Studio.
+
+For dev, avatar paths can point to:
+
+- `http://127.0.0.1:54321/storage/v1/object/public/cv-assets/...`, or
+- `public/` static files until Storage upload is wired
+
+## CI
+
+GitHub Actions use **cloud** Supabase secrets only — not local stack.
+
+Playwright / Lighthouse CI can use:
+
+- Mocked fetch (fast), or
+- Cloud staging read-only project, or
+- Pre-seeded build without live Supabase (fixture JSON) — decide in Phase 5
+
+## Troubleshooting
+
+| Issue                  | Fix                                     |
+| ---------------------- | --------------------------------------- |
+| `supabase start` fails | Docker running? Port 54321–54323 free?  |
+| Stale schema           | `supabase db reset`                     |
+| Wrong API URL in build | Check `.env.local` vs `.env.production` |
+| Types out of sync      | `pnpm run db:types` after migration     |
+
+## Related
+
+- [supabase-schema.md](./supabase-schema.md) — table design
+- [deploy.md](./deploy.md) — cloud webhooks + GitHub Pages
+- [phases.md](./phases.md) — Phase 2 tasks

--- a/docs/projects/next-shadcn-supabase-rewrite/phases.md
+++ b/docs/projects/next-shadcn-supabase-rewrite/phases.md
@@ -1,0 +1,141 @@
+# Implementation phases
+
+## Phase 0 — Planning
+
+**Status:** mostly complete
+
+- [x] Project brief and architecture docs
+- [x] Deploy: **GitHub Pages**
+- [x] Branch: **`v2`**
+- [x] Rebuild: **Supabase Database Webhook → GitHub**
+- [x] Approve schema: **editor-first hybrid** (`_en`/`_hu` columns, child
+      tables)
+- [x] Package manager: **pnpm** on `v2`
+- [x] Local dev: **self-hosted Supabase** (CLI + Docker)
+- [ ] Create Supabase **cloud** project (staging / CI / prod)
+
+**Exit:** `supabase start` works locally; cloud project for CI — then create
+`v2` branch for Phase 1.
+
+---
+
+## Phase 1 — Scaffold
+
+**Goal:** Empty Next app with toolchain.
+
+- [ ] Create branch `v2` from `main`
+- [ ] `packageManager` in `package.json`; remove `package-lock.json` on `v2`
+- [ ] `pnpm create next-app` (or manual) — App Router, TypeScript, Tailwind,
+      ESLint
+- [ ] Add shadcn/ui — `pnpm dlx shadcn@latest init` + base components
+- [ ] Folder layout per [architecture.md](./architecture.md)
+- [ ] `next.config.ts` — `output: 'export'`, `images.unoptimized: true`
+- [ ] Port `messages/en.json`, `messages/hu.json` from `i18n/locales/`
+- [ ] Basic layout shell (dark gradient background, grid pattern)
+
+**Exit:** `pnpm run build` succeeds; placeholder page renders.
+
+---
+
+## Phase 2 — Supabase + data layer
+
+**Goal:** CV data in Supabase; fetch at build time.
+
+- [ ] `supabase init` + `config.toml`; add `db:*` scripts to `package.json`
+- [ ] Migrations per [supabase-schema.md](./supabase-schema.md) (editor-first
+      hybrid)
+- [ ] `supabase db reset` — apply migrations + seed locally
+- [ ] Seed script: YAML → structured rows (not JSON blob)
+- [ ] `lib/cv/fetch.ts` + `lib/cv/map-from-db.ts` + types
+- [ ] `lib/site-config.ts`
+- [ ] Verify fetch in Server Component (log output in dev)
+
+**Exit:** `getCvProfile('gabor-pichner', 'en')` works against **local** Supabase
+(`supabase start`).
+
+See [local-supabase.md](./local-supabase.md).
+
+---
+
+## Phase 3 — UI port
+
+**Goal:** Visual and functional parity with Nuxt components.
+
+| Component        | Source                   | Notes                   |
+| ---------------- | ------------------------ | ----------------------- |
+| Header           | `app/components/Header/` | Avatar, social, contact |
+| Experience       | `Experience/`            | JobPosting microdata    |
+| Education        | `Education/`             |                         |
+| Skills           | `Skills/`                |                         |
+| Hobbies          | `Hobbies/`               |                         |
+| LanguageSelector | client component         |                         |
+| CookieConsent    | client component         |                         |
+| SectionTitle     | shadcn + custom          |                         |
+
+- [ ] Loading skeleton (optional — static build may skip)
+- [ ] Print styles (port from SCSS `@media print`)
+- [ ] Responsive layout matches current
+
+**Exit:** Side-by-side visual review `/` and `/hu`.
+
+---
+
+## Phase 4 — SEO + i18n
+
+**Goal:** Meet [seo-parity.md](./seo-parity.md).
+
+- [ ] `generateMetadata` per locale
+- [ ] `structured-data.tsx`
+- [ ] `sitemap.ts`, `robots.ts`
+- [ ] `llms.txt` route
+- [ ] hreflang alternates
+- [ ] GA production-only
+- [ ] Favicon from site config
+
+**Exit:** Lighthouse SEO 100% on local static serve.
+
+---
+
+## Phase 5 — CI + testing
+
+**Goal:** Replace Nuxt CI with Next equivalents.
+
+- [ ] ESLint + TypeScript in CI
+- [ ] `next build` with Supabase secrets in CI
+- [ ] Playwright smoke tests — port/adapt from `tests/` (page load, locale
+      switch, sections visible)
+- [ ] Deploy workflow: GitHub Pages from `out/` on `v2` push
+- [ ] Supabase Database Webhook → `repository_dispatch` (see
+      [deploy.md](./deploy.md))
+- [ ] Lighthouse job — serve `out/` directory
+- [ ] Percy visual regression (optional first pass)
+- [ ] Docker build if keeping container deploy
+
+**Exit:** PR CI green on feature branch.
+
+---
+
+## Phase 6 — Cutover
+
+**Goal:** Production on new stack.
+
+- [ ] Production Supabase project + seed
+- [ ] Deploy preview URL review
+- [ ] Merge `v2` → `main`
+- [ ] Configure Supabase production webhooks → deploy on `main`
+- [ ] Update workflow branch filters (`v2` → `main`)
+- [ ] Remove or archive Nuxt dependencies
+- [ ] Update `docs/.ai/architecture.md`, `docs/content.md`, `docs/setup.md`
+- [ ] Tag release
+
+**Exit:** https://95gabor.me serves Next build; old stack deprecated.
+
+---
+
+## Post–public-site-v1
+
+- **CV Editor UI** — form-based admin per
+  [supabase-schema.md](./supabase-schema.md#future-cv-editor-ui)
+- Image upload to Storage from editor
+- Multiple CV profiles (optional)
+- ISR on Vercel instead of full rebuild

--- a/docs/projects/next-shadcn-supabase-rewrite/seo-parity.md
+++ b/docs/projects/next-shadcn-supabase-rewrite/seo-parity.md
@@ -1,0 +1,136 @@
+# SEO parity checklist — Nuxt → Next
+
+Baseline: current site + `.lighthouserc.json` CI gates.
+
+## Lighthouse CI
+
+| Assertion                         | Current | Next implementation                       |
+| --------------------------------- | ------- | ----------------------------------------- |
+| `categories:seo` ≥ 1.0            | ✅      | Static HTML, semantic headings, meta      |
+| `categories:accessibility` ≥ 0.95 | ✅      | shadcn/Radix primitives; manual audit     |
+| `color-contrast`                  | ✅      | shadcn theme tokens; verify orange accent |
+| `target-size`                     | ✅      | Touch targets on links/buttons            |
+
+Update `.lighthouserc.json` `startServerCommand` to serve Next `out/` directory.
+
+## Meta tags
+
+| Feature          | Current (Nuxt)               | Next target                                     |
+| ---------------- | ---------------------------- | ----------------------------------------------- |
+| `<title>`        | `MetaData.vue` + `config.ts` | `export const metadata` or `generateMetadata()` |
+| `description`    | `useHead` meta               | `metadata.description`                          |
+| `keywords`       | joined array                 | `metadata.keywords`                             |
+| `og:title`       | `useHead`                    | `openGraph.title`                               |
+| `og:description` | `useHead`                    | `openGraph.description`                         |
+| `og:type`        | `profile`                    | `openGraph.type: 'profile'`                     |
+| `canonical`      | `link rel=canonical`         | `metadata.alternates.canonical`                 |
+| `robots`         | `index, follow`              | `metadata.robots`                               |
+| `html lang`      | dynamic per locale           | `layout` `lang={locale}`                        |
+| `viewport`       | head meta                    | default Next metadata                           |
+
+## Structured data (JSON-LD)
+
+Port `app/components/StructuredData.vue`:
+
+| Schema          | Fields                                               |
+| --------------- | ---------------------------------------------------- |
+| `Person`        | name, jobTitle, image, url, sameAs, email, telephone |
+| `worksFor`      | Organization per job                                 |
+| `alumniOf`      | EducationalOrganization                              |
+| `knowsAbout`    | skills                                               |
+| `hasOccupation` | JobPosting-derived from work experience              |
+
+Implementation: `<script type="application/ld+json">` in layout or dedicated
+Server Component.
+
+## Sitemap
+
+| Current                | Next             |
+| ---------------------- | ---------------- |
+| `@nuxtjs/sitemap` auto | `app/sitemap.ts` |
+
+```typescript
+// Minimum entries
+[
+  '/',
+] // en
+['/hu']; // hu
+```
+
+Include `lastModified` from `cv_profiles.updated_at` when available.
+
+## Robots
+
+| Current          | Next            |
+| ---------------- | --------------- |
+| `@nuxtjs/robots` | `app/robots.ts` |
+
+```
+User-agent: *
+Allow: /
+Sitemap: https://95gabor.me/sitemap.xml
+```
+
+## i18n SEO
+
+| Current                 | Next                                   |
+| ----------------------- | -------------------------------------- |
+| `prefix_except_default` | `/` = en, `/hu` = hu                   |
+| `hreflang`              | Add `alternates.languages` in metadata |
+
+```typescript
+alternates: {
+  canonical: 'https://95gabor.me',
+  languages: {
+    en: 'https://95gabor.me',
+    hu: 'https://95gabor.me/hu',
+  },
+},
+```
+
+## llms.txt
+
+| Current            | Next                                    |
+| ------------------ | --------------------------------------- |
+| `nuxt-llms` module | `app/llms.txt/route.ts` or build script |
+
+Port content from `scripts/generate-llm-config.ts`.
+
+## Analytics
+
+| Current                            | Next                                             |
+| ---------------------------------- | ------------------------------------------------ |
+| `@nuxt/scripts` GA production only | `@next/third-parties/google` or env-gated Script |
+
+Load only when `NODE_ENV === 'production'`.
+
+## Semantic HTML
+
+Preserve from current components:
+
+- `<header role="banner">`
+- `<main role="main">`
+- `<article itemscope itemtype="Person">`
+- Section `aria-labelledby`
+- Job items `itemtype="JobPosting"`
+
+## Performance (non-Lighthouse but important)
+
+| Concern                        | Approach                                                                              |
+| ------------------------------ | ------------------------------------------------------------------------------------- |
+| No runtime Supabase on CV page | Build-time fetch only                                                                 |
+| Images                         | `next/image` with static export config or plain `<img>` for exported paths            |
+| Fonts                          | `next/font` — subset, display swap                                                    |
+| JS bundle                      | Server Components default; minimal client islands (language switcher, cookie consent) |
+| Third-party scripts            | GA only in prod; defer                                                                |
+
+## Verification before cutover
+
+- [ ] Lighthouse CI green on PR
+- [ ] Manual check: View Source has JSON-LD
+- [ ] `curl https://<preview>/sitemap.xml`
+- [ ] `curl https://<preview>/robots.txt`
+- [ ] `curl https://<preview>/llms.txt`
+- [ ] Google Rich Results Test on preview URL
+- [ ] Compare `/` and `/hu` meta + lang attribute
+- [ ] Percy or manual visual diff vs current site

--- a/docs/projects/next-shadcn-supabase-rewrite/supabase-schema.md
+++ b/docs/projects/next-shadcn-supabase-rewrite/supabase-schema.md
@@ -1,0 +1,269 @@
+# Supabase schema — CV content model
+
+Maps the current Zod schema (`app/types/cv.ts`) and `content/gabor-pichner.yaml`
+to Postgres.
+
+## Approach (locked)
+
+**Editor-first hybrid** — structured tables for humans and developers, **no
+single JSON/YAML document**.
+
+| Audience       | Experience                                                              |
+| -------------- | ----------------------------------------------------------------------- |
+| CV editor (UI) | Forms, lists, drag-reorder — never raw JSON/YAML                        |
+| Developers     | Readable SQL rows/columns in Supabase; typed fetch in `lib/cv/types.ts` |
+| Public site    | Build-time fetch → same domain model as today                           |
+
+### Why not a single JSONB blob?
+
+A one-column `content jsonb` is fast to migrate but **bad for both goals**:
+editors end up in a JSON panel; developers stare at an opaque blob.
+
+### Why not fully normalized?
+
+Separate `localized_strings` / translation tables add complexity without benefit
+for **one CV** and two locales. Use **`_en` / `_hu` column pairs** instead —
+readable and form-friendly.
+
+### JSONB usage
+
+Use JSONB **only** where unavoidable (none required in v1). Prefer explicit
+columns and child tables.
+
+## Entity diagram
+
+```mermaid
+erDiagram
+    site_config ||--o{ cv_profiles : owns
+    cv_profiles ||--o{ personal_links : has
+    cv_profiles ||--o{ personal_contacts : has
+    cv_profiles ||--o{ work_experiences : has
+    cv_profiles ||--o{ educations : has
+    cv_profiles ||--o{ skills : has
+    cv_profiles ||--o{ hobbies : has
+    work_experiences ||--o{ work_experience_technologies : has
+
+    cv_profiles {
+        uuid id PK
+        text slug UK
+        text name_en
+        text name_hu
+        text title_en
+        text title_hu
+        text picture_path
+        boolean is_active
+        timestamptz updated_at
+    }
+
+    work_experiences {
+        uuid id PK
+        uuid cv_profile_id FK
+        int sort_order
+        text title_en
+        text title_hu
+        text company_name
+        text company_link
+        text location
+        int from_year
+        int from_month
+        int end_year
+        int end_month
+        text employment_type
+        text description_en
+        text description_hu
+    }
+```
+
+## Tables
+
+### `site_config`
+
+Single row (`id = 'default'`).
+
+| Column         | Type   | Editor UI             |
+| -------------- | ------ | --------------------- |
+| `url`          | text   | Site URL input        |
+| `title`        | text   | SEO title             |
+| `description`  | text   | Textarea              |
+| `keywords`     | text[] | Tag input             |
+| `favicon_path` | text   | File picker → Storage |
+
+### `cv_profiles`
+
+| Column                 | Type        | Editor UI                             |
+| ---------------------- | ----------- | ------------------------------------- |
+| `slug`                 | text UNIQUE | Read-only after create                |
+| `name_en`, `name_hu`   | text        | Bilingual name fields                 |
+| `title_en`, `title_hu` | text        | Bilingual job headline                |
+| `picture_path`         | text        | Avatar upload → Storage               |
+| `is_active`            | boolean     | Toggle (which profile the site loads) |
+| `updated_at`           | timestamptz | Auto — webhook trigger source         |
+
+### `personal_links`
+
+| Column            | Type    | Editor UI                           |
+| ----------------- | ------- | ----------------------------------- |
+| `cv_profile_id`   | uuid FK | —                                   |
+| `sort_order`      | int     | Drag handle                         |
+| `platform`        | text    | Select / text (GitHub, LinkedIn, …) |
+| `url`             | text    | URL input                           |
+| `icon_dark_path`  | text    | Icon upload                         |
+| `icon_light_path` | text    | Icon upload                         |
+
+### `personal_contacts`
+
+| Column          | Type      | Editor UI                       |
+| --------------- | --------- | ------------------------------- |
+| `cv_profile_id` | uuid FK   | —                               |
+| `sort_order`    | int       | Drag handle                     |
+| `type`          | text enum | location / phone / email / link |
+| `value`         | text      | Text / URL input                |
+
+### `work_experiences`
+
+| Column                             | Type          | Editor UI                          |
+| ---------------------------------- | ------------- | ---------------------------------- |
+| `sort_order`                       | int           | Reorder jobs                       |
+| `title_en`, `title_hu`             | text          | Bilingual                          |
+| `company_name`                     | text          | Text                               |
+| `company_link`                     | text nullable | URL                                |
+| `location`                         | text          | Text                               |
+| `from_year`, `from_month`          | int           | Date pickers                       |
+| `end_year`, `end_month`            | int nullable  | “Current role” checkbox clears end |
+| `employment_type`                  | text nullable | Select (maps to i18n key)          |
+| `description_en`, `description_hu` | text          | Rich textarea / markdown           |
+
+### `work_experience_technologies`
+
+| Column               | Type    | Editor UI |
+| -------------------- | ------- | --------- |
+| `work_experience_id` | uuid FK | —         |
+| `sort_order`         | int     | Reorder   |
+| `name`               | text    | Text      |
+| `link`               | text    | URL       |
+
+### `educations`
+
+Same pattern as jobs: `degree_en/hu`, `institution_name`, `institution_link`,
+`location`, period columns, `note_en/hu` optional.
+
+### `skills`
+
+| Column       | Type          | Editor UI |
+| ------------ | ------------- | --------- |
+| `name`       | text          | Text      |
+| `link`       | text nullable | URL       |
+| `sort_order` | int           | Reorder   |
+
+### `hobbies`
+
+| Column               | Type          | Editor UI |
+| -------------------- | ------------- | --------- |
+| `name_en`, `name_hu` | text          | Bilingual |
+| `link`               | text nullable | URL       |
+| `sort_order`         | int           | Reorder   |
+
+## UI editor → database mapping
+
+```mermaid
+flowchart LR
+    subgraph editor [CV Editor UI]
+        Personal[Personal section]
+        Jobs[Jobs list]
+        JobForm[Job form EN/HU tabs]
+        Tech[Technologies sub-list]
+    end
+
+    subgraph db [Supabase]
+        CP[cv_profiles]
+        PL[personal_links]
+        WE[work_experiences]
+        WET[work_experience_technologies]
+    end
+
+    Personal --> CP
+    Personal --> PL
+    Jobs --> WE
+    JobForm --> WE
+    Tech --> WET
+```
+
+**Editor rules:**
+
+- Every user-visible field maps to **one column** (or one row in a child table).
+- Bilingual content = **two inputs** (`_en`, `_hu`), not a JSON editor.
+- Lists = **add / edit / delete / reorder** rows — never edit arrays as text.
+- Save triggers `cv_profiles.updated_at` (via trigger on child tables) → webhook
+  → redeploy.
+
+## Developer readability
+
+Example row developers see in Supabase:
+
+```
+work_experiences:
+  title_en: "Full Stack Developer"
+  title_hu: "Full Stack Fejlesztő"
+  company_name: "it.hu"
+  from_year: 2026
+  from_month: 6
+```
+
+TypeScript layer maps flat columns → existing `CV` domain type
+(`LocalizedString`, etc.) in `lib/cv/map-from-db.ts`. Public site and tests keep
+the same shapes as `app/types/cv.ts`.
+
+## Webhook / `updated_at`
+
+Trigger on child tables bumps parent profile timestamp:
+
+```sql
+-- pseudocode: after insert/update/delete on work_experiences, educations, …
+update cv_profiles set updated_at = now() where id = <cv_profile_id>;
+```
+
+Single Supabase Database Webhook on `cv_profiles` UPDATE is enough for rebuild.
+
+## Storage
+
+| Bucket      | Contents              |
+| ----------- | --------------------- |
+| `cv-assets` | Avatars, social icons |
+
+Editor uploads file → Storage → saves path in `picture_path` / `icon_*_path`.
+
+## RLS
+
+| Role            | Policy                        |
+| --------------- | ----------------------------- |
+| `anon`          | SELECT published data         |
+| `authenticated` | CRUD for editor (owner/admin) |
+| `service_role`  | Build CI fetch only           |
+
+## Seed migration
+
+1. Parse `content/gabor-pichner.yaml` + `config.ts`
+2. Insert into structured tables (not one JSON blob)
+3. `lib/cv/map-from-db.ts` round-trip test against current Zod shapes
+
+Run against **local self-hosted** stack (`supabase start`) during development;
+push migrations to cloud for CI — see [local-supabase.md](./local-supabase.md).
+
+## UI strings
+
+Keep `messages/en.json` and `messages/hu.json` in git (section labels, buttons).
+CV body content lives in Supabase.
+
+## Future: CV Editor UI
+
+Post–public-site-v1; schema is designed for it now.
+
+| Screen           | CRUD target                                          |
+| ---------------- | ---------------------------------------------------- |
+| Personal         | `cv_profiles`, `personal_links`, `personal_contacts` |
+| Experience       | `work_experiences`, `work_experience_technologies`   |
+| Education        | `educations`                                         |
+| Skills / Hobbies | `skills`, `hobbies`                                  |
+| Site SEO         | `site_config`                                        |
+
+Stack options: Next.js `/admin` route (auth via Supabase) or separate app — TBD.

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,49 @@
+# External references
+
+## Repo and deploy
+
+| Resource       | URL                                   |
+| -------------- | ------------------------------------- |
+| GitHub repo    | https://github.com/95gabor/cv         |
+| Live site      | https://95gabor.me                    |
+| GitHub Actions | https://github.com/95gabor/cv/actions |
+| GHCR image     | `ghcr.io/95gabor/cv` (after tag push) |
+
+## CI/CD workflows
+
+| Workflow       | Trigger             | Purpose                                           |
+| -------------- | ------------------- | ------------------------------------------------- |
+| `ci.yaml`      | PR / push to `main` | lint, typecheck, generate, E2E, Lighthouse, Percy |
+| `publish.yaml` | `v*` tag            | GitHub Pages deploy + Docker push                 |
+| `release.yaml` | `workflow_dispatch` | semantic-release                                  |
+
+## Secrets (GitHub)
+
+| Secret                     | Usage                    |
+| -------------------------- | ------------------------ |
+| `PERCY_TOKEN`              | Visual regression CI     |
+| `RELEASE_BOT_GITHUB_TOKEN` | Release workflow         |
+| `GITHUB_TOKEN`             | Pages deploy (automatic) |
+
+## Documentation in the repo
+
+| File                      | Contents                                 |
+| ------------------------- | ---------------------------------------- |
+| `docs/.ai/README.md`      | Agent entry point                        |
+| `docs/content.md`         | CV YAML editing                          |
+| `content/example.yaml`    | Example CV data                          |
+| `app/types/cv.ts`         | Zod schema (source)                      |
+| `schema/cv.schema.json`   | Generated JSON Schema                    |
+| `AGENTS.md` / `SKILLS.md` | Agent guidelines (redirect / supplement) |
+
+## Framework documentation
+
+| Tool                 | Link                                |
+| -------------------- | ----------------------------------- |
+| Nuxt 4               | https://nuxt.com/docs               |
+| Nuxt Content         | https://content.nuxt.com            |
+| Nuxt UI              | https://ui.nuxt.com                 |
+| Vue 3                | https://vuejs.org                   |
+| Playwright           | https://playwright.dev              |
+| Tailwind CSS v4      | https://tailwindcss.com/docs        |
+| Conventional Commits | https://www.conventionalcommits.org |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,81 @@
+# Local development environment
+
+> Agent workflow:
+> [`.ai/workflows/local-setup.md`](./.ai/workflows/local-setup.md)
+
+## Prerequisites
+
+| Tool    | Version / notes                  |
+| ------- | -------------------------------- |
+| Node.js | ≥ 24.18.0 (`.nvmrc`: `24.18.0`)  |
+| npm     | Project uses `package-lock.json` |
+
+```bash
+nvm use    # if nvm is installed
+node -v    # verify
+```
+
+## First-time setup
+
+```bash
+git clone https://github.com/95gabor/cv.git
+cd cv
+npm ci
+npm run dev
+# → http://localhost:3000
+```
+
+## Common commands
+
+| Command                     | Purpose                                          |
+| --------------------------- | ------------------------------------------------ |
+| `npm run dev`               | Dev server with hot reload                       |
+| `npm run build`             | Production build                                 |
+| `npm run generate`          | Static site generation (`.output/public`)        |
+| `npm run preview`           | Preview production build                         |
+| `npm run lint` / `lint:fix` | ESLint                                           |
+| `npm run typecheck`         | Vue/TS type checking                             |
+| `npm run format`            | Prettier                                         |
+| `npm run test:e2e`          | Playwright functional tests                      |
+| `npm run test:e2e:ui`       | Playwright interactive UI                        |
+| `npm run test:e2e:visual`   | Percy visual regression (requires token locally) |
+| `npm run storybook`         | UI components in Storybook (`:6006`)             |
+| `npm run commit`            | Commitizen (Conventional Commits)                |
+
+## Quality gate (before PR)
+
+```bash
+npm ci
+npm run lint
+npm run typecheck
+npm run generate
+```
+
+## Editing CV content
+
+1. Edit `content/gabor-pichner.yaml` (or the CV file set in `config.ts`).
+2. The dev server hot-reloads content automatically.
+3. Details: [content.md](./content.md)
+
+## Docker (optional)
+
+```bash
+docker compose up --build
+# → http://localhost:8000
+```
+
+## Common issues
+
+| Issue                                   | Fix                                                              |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| Node version mismatch                   | `nvm use` or Node ≥ 24.18                                        |
+| `Another Nuxt build is already running` | Stop the parallel build, or `NUXT_IGNORE_LOCK=1`                 |
+| YAML validation error on build          | Check schema: `app/types/cv.ts`, example: `content/example.yaml` |
+| Percy visual test fails locally         | `PERCY_TOKEN` env var required                                   |
+
+## Setup checklist
+
+- [ ] `node -v` ≥ 24.18.0
+- [ ] `npm ci` succeeds
+- [ ] `npm run dev` → page loads
+- [ ] `npm run lint && npm run typecheck && npm run generate` passes

--- a/docs/templates/task-brief.md
+++ b/docs/templates/task-brief.md
@@ -1,0 +1,47 @@
+# Task brief template
+
+Copy to the start of a new chat or into `local/` for larger tasks.
+
+---
+
+## Task
+
+**Title:** [short description]
+
+**Affected areas:**
+
+- [ ] `content/*.yaml` — CV content
+- [ ] `app/components/` — UI
+- [ ] `app/assets/styles/` — SCSS
+- [ ] `i18n/` — UI translations
+- [ ] `.github/workflows/` — CI
+- [ ] `docs/` — documentation
+
+## Context
+
+[What is the problem / feature? Why is it needed?]
+
+## Acceptance criteria
+
+- [ ] ...
+- [ ] ...
+
+## Constraints
+
+- Do not change: ...
+- Quality gate: lint + typecheck + generate
+
+## Relevant files
+
+- `path/to/file`
+
+## Testing
+
+1. ...
+2. ...
+
+## Notes
+
+[Optional: screenshot, issue link]
+
+---


### PR DESCRIPTION
## Summary

- Add structured `docs/` tree for humans (`setup`, `content`, `conventions`) and agents (`docs/.ai/` with architecture, content model, workflows).
- Document the planned **Next.js + shadcn + Supabase** rewrite on `v2` (GitHub Pages, build-time fetch, editor-first schema, Playwright, pnpm).
- Include **local self-hosted Supabase** workflow (`supabase start` + Docker) for dev; cloud Supabase for CI/prod.
- Update root `README.md`, `AGENTS.md`, `SKILLS.md`, and add `.cursor/rules/cv-workspace.mdc` for workspace guidance.
- Add `docs/local/` for personal gitignored notes (only README + `.gitignore` committed).

## Test plan

- [ ] Review docs index at `docs/README.md` and agent entry at `docs/.ai/README.md`
- [ ] Verify rewrite project brief links resolve under `docs/projects/next-shadcn-supabase-rewrite/`
- [ ] Confirm no secrets or personal notes committed under `docs/local/`
- [ ] CI should pass (docs-only change; no app code modified)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new AI-focused documentation structure with workspace guidance, role routing, and workflow indexes.
  * Expanded repo docs with clearer setup, content editing, architecture, release, and quality-check instructions.
  * Introduced project planning docs for the upcoming Next.js + Supabase rewrite, including architecture, deployment, schema, SEO, and implementation phases.
  * Added templates and local-notes guidance to support consistent task planning and private draft work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->